### PR TITLE
Added coveralls support for online coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ python:
 #virtualenv:
 #  system_site_packages: true
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -r requirements.txt
-  - pip install mock python-gnupg
+  - pip install -r requirements-tests.txt
+  - pip install coveralls
 
-# command to run tests, e.g. python setup.py test
 script:
-  - python setup.py test
-
+  - coverage run setup.py test
+after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,11 @@ Django Database Backup
         :target: https://readthedocs.org/projects/django-dbbackup/?badge=latest
         :alt: Documentation Status
 
+
+.. image:: https://coveralls.io/repos/django-dbbackup/django-dbbackup/badge.svg?branch=master&service=github
+        :target: https://coveralls.io/github/django-dbbackup/django-dbbackup?branch=master
+
+
 This Django application provides management commands to help backup and
 restore your project database to AmazonS3, Dropbox or Local Disk.
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+pep8
+flake8
+mock
+coverage


### PR DESCRIPTION
Use of Coveralls for track code coverage online, actually (for my fork) https://coveralls.io/github/ZuluPro/django-dbbackup.

I added badge too.