### PR TITLE
Corrected PR #72 and added arg for passphrase

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -8,11 +8,11 @@ import os
 import tempfile
 import gzip
 import sys
+from getpass import getpass
 
-from ... import utils
-from ...dbcommands import DBCommands
-from ...storage.base import BaseStorage
-from ...storage.base import StorageError
+from dbbackup import utils
+from dbbackup.dbcommands import DBCommands
+from dbbackup.storage.base import BaseStorage, StorageError
 from dbbackup import settings as dbbackup_settings
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -42,7 +42,7 @@ class Command(LabelCommand):
         try:
             connection.close()
             self.filepath = options.get('filepath')
-            self.backup_extension = options.get('backup-extension') or 'backup'
+            self.backup_extension = options.get('backup_extension') or 'backup'
             self.servername = options.get('servername')
             self.decrypt = options.get('decrypt')
             self.uncompress = options.get('uncompress')
@@ -120,7 +120,7 @@ class Command(LabelCommand):
         import gnupg
 
         def get_passphrase():
-            return input('Input Passphrase: ')
+            return getpass('Input Passphrase: ') or None
 
         temp_dir = tempfile.mkdtemp(dir=dbbackup_settings.TMP_DIR)
         try:

--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -14,12 +14,14 @@ from dbbackup import utils
 from dbbackup.dbcommands import DBCommands
 from dbbackup.storage.base import BaseStorage, StorageError
 from dbbackup import settings as dbbackup_settings
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 from django.core.management.base import LabelCommand
 from django.utils import six
 from django.db import connection
+
 from optparse import make_option
 
 input = raw_input if six.PY2 else input  # @ReservedAssignment
@@ -34,6 +36,7 @@ class Command(LabelCommand):
         make_option("-s", "--servername", help="Use a different servername backup"),
         make_option("-l", "--list", action='store_true', default=False, help="List backups in the backup directory"),
         make_option("-c", "--decrypt", help="Decrypt data before restoring", default=False, action='store_true'),
+        make_option("-p", "--passphrase", help="Passphrase for decrypt file", default=None),
         make_option("-z", "--uncompress", help="Uncompress gzip data before restoring", action='store_true'),
     )
 
@@ -46,6 +49,7 @@ class Command(LabelCommand):
             self.servername = options.get('servername')
             self.decrypt = options.get('decrypt')
             self.uncompress = options.get('uncompress')
+            self.passphrase = options.get('passphrase')
             self.database = self._get_database(options)
             self.storage = BaseStorage.storage_factory()
             self.dbcommands = DBCommands(self.database)
@@ -120,7 +124,7 @@ class Command(LabelCommand):
         import gnupg
 
         def get_passphrase():
-            return getpass('Input Passphrase: ') or None
+            return self.passphrase or getpass('Input Passphrase: ') or None
 
         temp_dir = tempfile.mkdtemp(dir=dbbackup_settings.TMP_DIR)
         try:

--- a/dbbackup/tests/test_restore.py
+++ b/dbbackup/tests/test_restore.py
@@ -39,6 +39,7 @@ class DbrestoreCommandRestoreBackupTest(TestCase):
         self.command.uncompress = True
         self.command.restore_backup()
 
+    @patch('dbbackup.management.commands.dbrestore.getpass', return_value=None)
     def test_decrypt(self, *args):
         if six.PY3:
             self.skipTest("Decryption isn't implemented in Python3")
@@ -101,6 +102,7 @@ class DbrestoreCommandDecryptTest(TestCase):
         subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
 
     @patch('dbbackup.management.commands.dbrestore.input', return_value=None)
+    @patch('dbbackup.management.commands.dbrestore.getpass', return_value=None)
     def test_decrypt(self, *args):
         if six.PY3:
             self.skipTest("Decryption isn't implemented in Python3")

--- a/dbbackup/tests/test_restore.py
+++ b/dbbackup/tests/test_restore.py
@@ -21,6 +21,7 @@ class DbrestoreCommandRestoreBackupTest(TestCase):
         self.command.filepath = 'foofile'
         self.command.database = TEST_DATABASE
         self.command.dbcommands = DBCommands(TEST_DATABASE)
+        self.command.passphrase = None
         self.command.storage = FakeStorage()
 
     def test_no_filepath(self, *args):
@@ -98,6 +99,7 @@ class DbrestoreCommandUncompressTest(TestCase):
 class DbrestoreCommandDecryptTest(TestCase):
     def setUp(self):
         self.command = DbrestoreCommand()
+        self.command.passphrase = None
         cmd = ('gpg --import %s' % GPG_PRIVATE_PATH).split()
         subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
 


### PR DESCRIPTION
From sroussy's PR I:
- Remove ``import gnupg`` from main
- Changed relative import from dbbackup
- Added passphrase argument for set it from command line
- The passphrase is now set to `None` if is empty.