### PR TITLE
Added tests for mediabackup

### DIFF
--- a/dbbackup/tests/commands/test_dbbackup.py
+++ b/dbbackup/tests/commands/test_dbbackup.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
+from mock import patch
 from django.test import TestCase
 from django.utils import six
-from mock import patch
 from dbbackup.management.commands.dbbackup import Command as DbbackupCommand
 from dbbackup.dbcommands import DBCommands
 from dbbackup.tests.utils import FakeStorage, TEST_DATABASE

--- a/dbbackup/tests/test_mediabackup.py
+++ b/dbbackup/tests/test_mediabackup.py
@@ -1,0 +1,102 @@
+import subprocess
+from django.test import TestCase
+from dbbackup.management.commands.mediabackup import Command as DbbackupCommand
+from dbbackup.tests.utils import FakeStorage, DEV_NULL, HANDLED_FILES
+from dbbackup.tests.utils import GPG_PUBLIC_PATH
+
+
+class MediabackupBackupMediafilesTest(TestCase):
+    def setUp(self):
+        HANDLED_FILES.clean()
+        self.command = DbbackupCommand()
+        self.command.servername = 'foo-server'
+        self.command.storage = FakeStorage()
+        self.command.stdout = DEV_NULL
+
+    def test_func(self):
+        self.command.backup_mediafiles(encrypt=False, compress=False)
+        self.assertEqual(1, len(HANDLED_FILES['written_files']))
+
+    def test_compress(self):
+        self.command.backup_mediafiles(encrypt=False, compress=True)
+        self.assertEqual(1, len(HANDLED_FILES['written_files']))
+        self.assertTrue(HANDLED_FILES['written_files'][0][0].endswith('.gz'))
+
+    def test_encrypt(self):
+        cmd = ('gpg --import %s' % GPG_PUBLIC_PATH).split()
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+        self.command.backup_mediafiles(encrypt=True, compress=False)
+        self.assertEqual(1, len(HANDLED_FILES['written_files']))
+        outputfile = HANDLED_FILES['written_files'][0][1]
+        outputfile.seek(0)
+        self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
+
+    def test_compress_and_encrypt(self):
+        cmd = ('gpg --import %s' % GPG_PUBLIC_PATH).split()
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+        self.command.backup_mediafiles(encrypt=True, compress=True)
+        self.assertEqual(1, len(HANDLED_FILES['written_files']))
+        outputfile = HANDLED_FILES['written_files'][0][1]
+        outputfile.seek(0)
+        self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
+
+
+class MediabackupGetBackupBasenameTest(TestCase):
+    def setUp(self):
+        self.command = DbbackupCommand()
+        self.command.servername = 'foo-server'
+        self.command.storage = FakeStorage()
+
+    def test_func(self):
+        output = self.command.get_backup_basename()
+        self.assertTrue(output.endswith('.tar'))
+
+    def test_compress(self):
+        options = {'compress': True}
+        output = self.command.get_backup_basename(**options)
+        self.assertTrue(output.endswith('.tar.gz'))
+
+    def test_encrypt(self):
+        options = {'compress': True}
+        output = self.command.get_backup_basename(**options)
+        self.assertTrue(output.endswith('.tar.gz'))
+
+    def test_compress_and_encrypt(self):
+        options = {'compress': True}
+        output = self.command.get_backup_basename(**options)
+        self.assertTrue(output.endswith('.tar.gz'))
+
+
+class MediabackupGetBackupFileListTest(TestCase):
+    def setUp(self):
+        self.skipTest("Doesn't work!")
+        self.command = DbbackupCommand()
+        self.command.servername = 'foo-server'
+        self.command.storage = FakeStorage()
+
+    def test_func(self):
+        self.command.get_backup_file_list()
+
+
+class MediabackupCleanUpOldBackupsTest(TestCase):
+    def setUp(self):
+        self.skipTest("Doesn't work!")
+        self.command = DbbackupCommand()
+        self.command.servername = 'foo-server'
+        self.command.storage = FakeStorage()
+
+    def test_func(self):
+        self.command.cleanup_old_backups()
+
+
+class MediabackupGetServerNameTest(TestCase):
+    def setUp(self):
+        self.command = DbbackupCommand()
+
+    def test_func(self):
+        self.command.servername = 'foo-server'
+        self.command.get_servername()
+
+    def test_no_servername(self):
+        self.command.servername = ''
+        self.command.get_servername()

--- a/dbbackup/tests/utils.py
+++ b/dbbackup/tests/utils.py
@@ -34,8 +34,12 @@ HANDLED_FILES = handled_files()
 class FakeStorage(BaseStorage):
     name = 'FakeStorage'
     list_files = ['foo', 'bar']
-    deleted_files = []
     file_read = ENCRYPTED_FILE
+
+    def __init__(self, *args, **kwargs):
+        super(FakeStorage, self).__init__(*args, **kwargs)
+        self.deleted_files = []
+        self.written_files = []
 
     def delete_file(self, filepath):
         HANDLED_FILES['deleted_files'].append(filepath)


### PR DESCRIPTION
Tests are located in `dbbackup/test/test_mediabackup.py`, I will move it in `dbbackup/test/commands/test_mediabackup.py` after PR #78 has been merged.

`dbbackup.management.commands.mediabackup.Command.get_backup_file_list` doesn't seem to work. I written tests but skip them. 