### PR TITLE
Added Wrapper for use Django built-in storage system

### DIFF
--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -62,3 +62,5 @@ GPG_ALWAYS_TRUST = getattr(settings, 'DBBACKUP_GPG_ALWAYS_TRUST', False)
 GPG_RECIPIENT = GPG_ALWAYS_TRUST = getattr(settings, 'DBBACKUP_GPG_RECIPIENT', None)
 
 STORAGE = getattr(settings, 'DBBACKUP_STORAGE', 'dbbackup.storage.filesystem_storage')
+BUILTIN_STORAGE = getattr(settings, 'DBBACKUP_BUILTIN_STORAGE', None)
+STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})

--- a/dbbackup/storage/builtin_django.py
+++ b/dbbackup/storage/builtin_django.py
@@ -1,0 +1,29 @@
+"""
+Lazy storage adapted to Django buit-in one.
+"""
+from django.core.files.storage import get_storage_class
+from .base import BaseStorage
+from .. import settings
+
+
+class Storage(BaseStorage):
+    def __init__(self, storage_path=None, **options):
+        storage_path = storage_path or settings.BUILTIN_STORAGE
+        options = options.copy()
+        options.update(settings.STORAGE_OPTIONS)
+        self.storageCls = get_storage_class(storage_path)
+        self.storage = self.storageCls(**options)
+        self.name = self.storageCls.__name__
+        self.backup_dir = self.name
+
+    def delete_file(self, filepath):
+        self.storage.delete(name=filepath)
+
+    def list_directory(self):
+        return self.storage.listdir(path='')[1]
+
+    def write_file(self, filehandle, filename):
+        self.storage.save(name=filename, content=filehandle)
+
+    def read_file(self, filepath):
+        return self.storage.open(name=filepath, mode='rb')

--- a/dbbackup/storage/builtin_django.py
+++ b/dbbackup/storage/builtin_django.py
@@ -1,5 +1,5 @@
 """
-Lazy storage adapted to Django buit-in one.
+Wrapper around Django storage API.
 """
 from django.core.files.storage import get_storage_class
 from .base import BaseStorage
@@ -8,6 +8,14 @@ from .. import settings
 
 class Storage(BaseStorage):
     def __init__(self, storage_path=None, **options):
+        """
+        Initialize a Django Storage instance with given options.
+
+        :param storage_path: Path to a Django Storage class with dot style
+                             If ``None``, ``settings.DBBACKUP_BUILTIN_STORAGE``
+                             will be used.
+        :type storage_path: str
+        """
         storage_path = storage_path or settings.BUILTIN_STORAGE
         options = options.copy()
         options.update(settings.STORAGE_OPTIONS)

--- a/dbbackup/tests/storages/test_django.py
+++ b/dbbackup/tests/storages/test_django.py
@@ -1,0 +1,40 @@
+import os
+import tempfile
+import shutil
+from io import BytesIO
+from django.test import TestCase
+from dbbackup.storage.builtin_django import Storage as DjangoStorage
+
+
+class DjangoStorageTest(TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = DjangoStorage(location=self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_delete_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        open(file_path, 'w').close()
+        self.storage.delete_file('foo')
+        self.assertFalse(os.path.exists(file_path))
+
+    def test_list_directory(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        open(file_path, 'w').close()
+        files = self.storage.list_directory()
+        self.assertEqual(len(files), 1)
+
+    def test_write_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        self.storage.write_file(BytesIO(b'bar'), 'foo')
+        self.assertTrue(os.path.exists(file_path))
+        self.assertEqual(open(file_path).read(), 'bar')
+
+    def test_read_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        with open(file_path, 'w') as fd:
+            fd.write('bar')
+        read_file = self.storage.read_file('foo')
+        self.assertEqual(read_file.read(), b'bar')

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -142,3 +142,38 @@ credentionals. Skip for anonymous FTP.
 
 **DBBACKUP\_FTP\_PATH** - The directory on remote FTP server you wish to
 save your backups.
+
+Django built-in storage API
+---------------------------
+
+Django has its own storage API for managing media files. Dbbackup allows
+you to use (third-party) Django storage backends. The default backend is
+``FileSystemStorage``, which is integrated in Django but we invite you
+to take a look at `django-storages-redux`_ which has a great collection of
+storage backends.
+
+Django project settings
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To use Django's built-in `FileSystemStorage`_, add the following lines to
+your ``settings.py``::
+
+    DBBACKUP_STORAGE = 'dbbackup.storage.builtin_django'
+    # Default
+    # DBBACKUP_DJANGO_STORAGE = 'django.core.file.storages.FileSystemStorage'
+    DBBACKUP_STORAGE_OPTIONS = {'location': '/mybackupdir/'}
+
+Available Settings
+~~~~~~~~~~~~~~~~~~
+
+**DBBACKUP_DJANGO_STORAGE** - Path to a Django Storage class (in Python dot style).
+
+.. warning ::
+
+    Do not use a Django storage backend without configuring its options, otherwise you will risk mixing media files (with public access) and backups (strictly private).
+
+**DBBACKUP_STORAGE_OPTIONS** - Dictionary used to instantiate a Django Storage class. The ``location`` key customizes the directory for ``FileSystemStorage``.
+
+.. _django-storages-redux: https://github.com/jschneier/django-storages
+.. _FileSystemStorage: https://docs.djangoproject.com/en/1.8/ref/files/storage/#the-filesystemstorage-class
+


### PR DESCRIPTION
I made a small wrapper Storage class: ``dbbackup.storage.builtin_django.Storage``.
This class allows to use built-in Django storage system, defined in ``settings.DBBACKUP_BUILTIN_STORAGE``

User must define ``settings.DBBACKUP_STORAGE='dbbackup.storage.builtin_django'`` and can give storage's options with ``settings.DBBACKUP_STORAGE_OPTIONS``.

Of course, all is tested ;)
Documention updating is comming...