### PR TITLE
Added functionnal tests to dbrestore command

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -77,7 +77,8 @@ class Command(BaseDbBackupCommand):
         if not self.filepath:
             self.log("  Finding latest backup", 1)
             filepaths = self.storage.list_directory()
-            filepaths = [f for f in filepaths if f.endswith('.' + self.backup_extension)]
+            # TODO: It is a bad filter
+            # filepaths = [f for f in filepaths if f.endswith('.' + self.backup_extension)]
             if not filepaths:
                 raise CommandError("No backup files found in: /%s" % self.storage.backup_dir)
             self.filepath = filepaths[-1]

--- a/dbbackup/tests/functionnal/test_commands.py
+++ b/dbbackup/tests/functionnal/test_commands.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from io import BytesIO
 from mock import patch
 from django.test import TestCase
 from django.core.management import execute_from_command_line
@@ -43,3 +44,59 @@ class DbBackupCommandTest(TestCase):
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         filename, outputfile = HANDLED_FILES['written_files'][0]
         self.assertTrue(filename.endswith('.gz.gpg'))
+
+
+# TODO: Add fake database to restore
+@patch('django.conf.settings.DATABASES', {'default': TEST_DATABASE})
+@patch('dbbackup.settings.STORAGE', 'dbbackup.tests.utils.FakeStorage')
+@patch('dbbackup.management.commands.dbrestore.input', return_value='y')
+class DbRestoreCommandTest(TestCase):
+    def setUp(self):
+        if six.PY3:
+            self.skipTest("Compression isn't implemented in Python3")
+        HANDLED_FILES.clean()
+        cmd = ('gpg --import %s' % GPG_PUBLIC_PATH).split()
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+        open(TEST_DATABASE['NAME'], 'a').close()
+
+    def tearDown(self):
+        os.remove(TEST_DATABASE['NAME'])
+        clean_gpg_keys()
+
+    def test_restore(self, *args):
+        # Create backup
+        execute_from_command_line(['', 'dbbackup'])
+        # Restore
+        execute_from_command_line(['', 'dbrestore'])
+
+    @patch('dbbackup.management.commands.dbrestore.getpass', return_value=None)
+    def test_encrypted(self, *args):
+        # Create backup
+        execute_from_command_line(['', 'dbbackup', '--encrypt'])
+        # Restore
+        execute_from_command_line(['', 'dbrestore', '--decrypt'])
+
+    def test_compressed(self, *args):
+        # Create backup
+        execute_from_command_line(['', 'dbbackup', '--compress'])
+        # Restore
+        execute_from_command_line(['', 'dbrestore', '--uncompress'])
+
+    def test_no_backup_available(self, *args):
+        with self.assertRaises(SystemExit):
+            execute_from_command_line(['', 'dbrestore'])
+
+    # @patch('dbbackup.management.commands.dbrestore.getpass', return_value=None)
+    # def test_available_but_not_encrypted(self, *args):
+    #     # Create backup
+    #     execute_from_command_line(['', 'dbbackup'])
+    #     # Restore
+    #     with self.assertRaises(Exception):
+    #         execute_from_command_line(['', 'dbrestore', '--decrypt'])
+
+    # def test_available_but_not_compressed(self, *args):
+    #     # Create backup
+    #     execute_from_command_line(['', 'dbbackup'])
+    #     # Restore
+    #     with self.assertRaises(Exception):
+    #         execute_from_command_line(['', 'dbrestore', '--uncompress'])

--- a/dbbackup/tests/utils.py
+++ b/dbbackup/tests/utils.py
@@ -20,7 +20,11 @@ DEV_NULL = open(os.devnull, 'w')
 
 
 class handled_files(dict):
-    """Dict for gather information about fake storage and clean between tests."""
+    """
+    Dict for gather information about fake storage and clean between tests.
+    You should use the constant instance ``HANDLED_FILES`` and clean it
+    before tests.
+    """
     def __init__(self):
         super(handled_files, self).__init__()
         self.clean()
@@ -33,7 +37,6 @@ HANDLED_FILES = handled_files()
 
 class FakeStorage(BaseStorage):
     name = 'FakeStorage'
-    list_files = ['foo', 'bar']
     file_read = ENCRYPTED_FILE
 
     def __init__(self, *args, **kwargs):
@@ -46,13 +49,13 @@ class FakeStorage(BaseStorage):
         self.deleted_files.append(filepath)
 
     def list_directory(self, raw=False):
-        return self.list_files
+        return [f[0] for f in HANDLED_FILES['written_files']]
 
     def write_file(self, filehandle, filename):
         HANDLED_FILES['written_files'].append((filename, filehandle))
 
     def read_file(self, filepath):
-        return open(self.file_read, 'rb')
+        return [f[1] for f in HANDLED_FILES['written_files'] if f[0] == filepath][0]
 
 Storage = FakeStorage
 


### PR DESCRIPTION
Added test with FakeStorage:
- For simple backup
- Encrypted backup
- Compressed backup

In 2nd comit, I also remove the extension filter in dbrestore L81, its filter is bad...
And my tests doesn't work with.

I added filtered tests (they fail) for test to restore uncrypt non-encrypted backup and uncompress non-compress. 
