### PR TITLE
Change FileSystem storage for use the Django's one

### DIFF
--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -1,11 +1,10 @@
 # DO NOT IMPORT THIS BEFORE django.configure() has been run!
 
 import os
+import warnings
 from django.conf import settings
 
 DATABASES = getattr(settings, 'DBBACKUP_DATABASES', list(settings.DATABASES.keys()))
-
-BACKUP_DIRECTORY = getattr(settings, 'DBBACKUP_BACKUP_DIRECTORY', os.getcwd())
 
 # Fake host
 DBBACKUP_FAKE_HOST = getattr(settings, 'DBBACKUP_FAKE_HOST', 'django-dbbackup')
@@ -64,3 +63,8 @@ GPG_RECIPIENT = GPG_ALWAYS_TRUST = getattr(settings, 'DBBACKUP_GPG_RECIPIENT', N
 STORAGE = getattr(settings, 'DBBACKUP_STORAGE', 'dbbackup.storage.filesystem_storage')
 BUILTIN_STORAGE = getattr(settings, 'DBBACKUP_BUILTIN_STORAGE', None)
 STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})
+
+if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):
+    BACKUP_DIRECTORY = STORAGE_OPTIONS['location'] = \
+        getattr(settings, 'DBBACKUP_BACKUP_DIRECTORY', os.getcwd())
+    warnings.warn("DBBACKUP_BACKUP_DIRECTORY is deprecated, use DBBACKUP_STORAGE_OPTIONS['location']", DeprecationWarning)

--- a/dbbackup/storage/builtin_django.py
+++ b/dbbackup/storage/builtin_django.py
@@ -22,7 +22,6 @@ class Storage(BaseStorage):
         self.storageCls = get_storage_class(storage_path)
         self.storage = self.storageCls(**options)
         self.name = self.storageCls.__name__
-        self.backup_dir = self.name
 
     def delete_file(self, filepath):
         self.storage.delete(name=filepath)

--- a/dbbackup/tests/storages/test_filesystem.py
+++ b/dbbackup/tests/storages/test_filesystem.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+import shutil
+from io import BytesIO
+from mock import patch
+from django.test import TestCase
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from dbbackup.storage.filesystem_storage import Storage as FileSystemStorage
+
+
+class FileSystemStorageTest(TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = FileSystemStorage(location=self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_delete_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        open(file_path, 'w').close()
+        self.storage.delete_file('foo')
+        self.assertFalse(os.listdir(self.temp_dir))
+
+    def test_list_directory(self):
+        file_path1 = os.path.join(self.temp_dir, 'foo')
+        file_path2 = os.path.join(self.temp_dir, 'bar')
+        self.assertEqual(0, len(os.listdir(self.temp_dir)))
+        open(file_path1, 'w').close()
+        self.assertEqual(1, len(os.listdir(self.temp_dir)))
+        open(file_path2, 'w').close()
+        self.assertEqual(2, len(os.listdir(self.temp_dir)))
+
+    def test_write_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        self.storage.write_file(BytesIO(b'bar'), 'foo')
+        self.assertTrue(os.path.exists(file_path))
+        self.assertEqual(open(file_path).read(), 'bar')
+
+    def test_read_file(self):
+        file_path = os.path.join(self.temp_dir, 'foo')
+        with open(file_path, 'w') as fd:
+            fd.write('bar')
+        read_file = self.storage.read_file('foo')
+        self.assertEqual(read_file.read(), b'bar')
+
+    def test_no_location(self):
+        with self.assertRaises(Exception):
+            self.storage = FileSystemStorage(location=None)
+
+    def test_backup_in_media_file(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.storage = FileSystemStorage(location=settings.MEDIA_ROOT)
+
+    @patch('django.conf.settings.DEBUG', True)
+    def test_backup_in_media_file_debug(self):
+        self.storage = FileSystemStorage(location=settings.MEDIA_ROOT)


### PR DESCRIPTION
After PR #64, I thought it is useless to have a custom FileSystem Storage since Django has one.
For maintain compatibility and ease users configuration I made a new FileSystemStorage. 

Like before ``settings.DBBACKUP_BACKUP_DIRECTORY`` is used, but I think it is deprecated now with the Django FileSystemStorage's ``location`` and ``settings.DBBACKUP_STORAGE_OPTIONS``

I added some check in ``Storage._check_filesystem_error``. Use can't set backup directory in media root when debug is false.

All tested!