### PR TITLE
Move unencrypt, compress and uncompress in dbbackup.utils

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -3,11 +3,9 @@ Restore database.
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
+
 import os
-import tempfile
-import gzip
 import sys
-from getpass import getpass
 
 from django.conf import settings
 from django.core.management.base import CommandError
@@ -16,11 +14,10 @@ from django.db import connection
 
 from optparse import make_option
 
-from dbbackup.management.commands._base import BaseDbBackupCommand
-from dbbackup import utils
-from dbbackup.dbcommands import DBCommands
-from dbbackup.storage.base import BaseStorage, StorageError
-from dbbackup import settings as dbbackup_settings
+from ._base import BaseDbBackupCommand
+from ... import utils
+from ...dbcommands import DBCommands
+from ...storage.base import BaseStorage, StorageError
 
 input = raw_input if six.PY2 else input  # @ReservedAssignment
 
@@ -86,11 +83,11 @@ class Command(BaseDbBackupCommand):
         input_filename = self.filepath
         inputfile = self.storage.read_file(input_filename)
         if self.decrypt:
-            unencrypted_file, input_filename = self.unencrypt_file(inputfile, input_filename)
+            unencrypted_file, input_filename = utils.unencrypt_file(inputfile, input_filename, self.passphrase)
             inputfile.close()
             inputfile = unencrypted_file
         if self.uncompress:
-            uncompressed_file = self.uncompress_file(inputfile)
+            uncompressed_file, input_filename = utils.uncompress_file(inputfile, input_filename)
             inputfile.close()
             inputfile = uncompressed_file
         self.log("  Restore tempfile created: %s" % utils.handle_size(inputfile), 1)
@@ -105,54 +102,8 @@ class Command(BaseDbBackupCommand):
         _, extension = os.path.splitext(filename)
         return extension
 
-    def uncompress_file(self, inputfile):
-        """ Uncompress this file using gzip. The input and the output are filelike objects. """
-        outputfile = tempfile.SpooledTemporaryFile(
-            max_size=500 * 1024 * 1024,
-            dir=dbbackup_settings.TMP_DIR)
-        zipfile = gzip.GzipFile(fileobj=inputfile, mode="rb")
-        try:
-            inputfile.seek(0)
-            outputfile.write(zipfile.read())
-        finally:
-            zipfile.close()
-        return outputfile
-
-    def unencrypt_file(self, inputfile, inputfilename):
-        """ Unencrypt this file using gpg. The input and the output are filelike objects. """
-        import gnupg
-
-        def get_passphrase():
-            return self.passphrase or getpass('Input Passphrase: ') or None
-
-        temp_dir = tempfile.mkdtemp(dir=dbbackup_settings.TMP_DIR)
-        try:
-            new_basename = os.path.basename(inputfilename).replace('.gpg', '')
-            temp_filename = os.path.join(temp_dir, new_basename)
-            try:
-                inputfile.seek(0)
-                g = gnupg.GPG()
-                result = g.decrypt_file(file=inputfile, passphrase=get_passphrase(), output=temp_filename)
-                if not result:
-                    raise Exception('Decryption failed; status: %s' % result.status)
-                outputfile = tempfile.SpooledTemporaryFile(
-                    max_size=10 * 1024 * 1024,
-                    dir=dbbackup_settings.TMP_DIR)
-                outputfile.name = new_basename
-                f = open(temp_filename)
-                try:
-                    outputfile.write(f.read())
-                finally:
-                    f.close()
-            finally:
-                if os.path.exists(temp_filename):
-                    os.remove(temp_filename)
-        finally:
-            os.rmdir(temp_dir)
-        return outputfile, new_basename
-
     def list_backups(self):
-        """ List backups in the backup directory. """
+        """List backups in the backup directory."""
         self.log("Listing backups on %s in /%s:" % (self.storage.name, self.storage.backup_dir), 1)
         for filepath in self.storage.list_directory():
             self.log("  %s" % os.path.basename(filepath), 1)

--- a/dbbackup/tests/commands/test_dbbackup.py
+++ b/dbbackup/tests/commands/test_dbbackup.py
@@ -13,8 +13,6 @@ from dbbackup.tests.utils import GPG_PUBLIC_PATH, DEV_NULL, GPG_FINGERPRINT
 @patch('sys.stdout', DEV_NULL)
 class DbbackupCommandSaveNewBackupTest(TestCase):
     def setUp(self):
-        if six.PY3:
-            self.skipTest("Compression isn't implemented in Python3")
         open(TEST_DATABASE['NAME'], 'a+b').close()
         self.command = DbbackupCommand()
         self.command.servername = 'foo-server'
@@ -65,19 +63,3 @@ class DbbackupCommandCleanupOldBackupsTest(TestCase):
     def test_cleanup_empty(self):
         self.command.storage.list_files = []
         self.command.cleanup_old_backups(TEST_DATABASE)
-
-
-class DbbackupCommandCompressFileTest(TestCase):
-    def setUp(self):
-        if six.PY3:
-            self.skipTest("Compression isn't implemented in Python3")
-        open(TEST_DATABASE['NAME'], 'a+b').close()
-        self.command = DbbackupCommand()
-        self.command.database = TEST_DATABASE['NAME']
-        self.command.dbcommands = DBCommands(TEST_DATABASE)
-        self.command.storage = FakeStorage()
-        self.command.stdout = DEV_NULL
-
-    def test_compress_file(self):
-        inputfile = open(TEST_DATABASE['NAME'])
-        self.command.compress_file(inputfile, 'foofile.txt')

--- a/dbbackup/tests/functionnal/test_commands.py
+++ b/dbbackup/tests/functionnal/test_commands.py
@@ -3,7 +3,6 @@ import subprocess
 from mock import patch
 from django.test import TestCase
 from django.core.management import execute_from_command_line
-from django.utils import six
 from dbbackup.tests.utils import TEST_DATABASE, HANDLED_FILES, clean_gpg_keys
 from dbbackup.tests.utils import GPG_PUBLIC_PATH, DEV_NULL
 
@@ -12,8 +11,6 @@ from dbbackup.tests.utils import GPG_PUBLIC_PATH, DEV_NULL
 @patch('dbbackup.settings.STORAGE', 'dbbackup.tests.utils.FakeStorage')
 class DbBackupCommandTest(TestCase):
     def setUp(self):
-        if six.PY3:
-            self.skipTest("Compression isn't implemented in Python3")
         HANDLED_FILES.clean()
         cmd = ('gpg --import %s' % GPG_PUBLIC_PATH).split()
         subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from mock import patch
 try:
     from StringIO import StringIO
 except ImportError:  # Py3
@@ -7,8 +8,10 @@ except ImportError:  # Py3
 from django.test import TestCase
 from django.core import mail
 from django.conf import settings
-from mock import patch
-from dbbackup import utils
+
+from .. import utils
+from .utils import (ENCRYPTED_FILE, clean_gpg_keys, GPG_PRIVATE_PATH,
+                    COMPRESSED_FILE)
 
 GPG_PUBLIC_PATH = os.path.join(settings.BASE_DIR, 'tests/gpg/pubring.gpg')
 DEV_NULL = open(os.devnull, 'w')
@@ -78,6 +81,46 @@ class Encrypt_FileTest(TestCase):
                                                           filename='foo.txt')
         encrypted_file.seek(0)
         self.assertTrue(encrypted_file.read())
+
+
+class Unencrypt_FileTest(TestCase):
+    def setUp(self):
+        cmd = ('gpg --import %s' % GPG_PRIVATE_PATH).split()
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+
+    def tearDown(self):
+        clean_gpg_keys()
+
+    @patch('dbbackup.utils.input', return_value=None)
+    @patch('dbbackup.utils.getpass', return_value=None)
+    def test_unencrypt(self, *args):
+        inputfile = open(ENCRYPTED_FILE, 'r+b')
+        uncryptfile, filename = utils.unencrypt_file(inputfile, 'foofile.gpg')
+        uncryptfile.seek(0)
+        self.assertEqual(b'foo\n', uncryptfile.read())
+
+
+class Compress_FileTest(TestCase):
+    def setUp(self):
+        self.path = '/tmp/foo'
+        with open(self.path, 'a+b') as fd:
+            fd.write(b'foo')
+
+    def tearDown(self):
+        os.remove(self.path)
+
+    def test_func(self, *args):
+        with open(self.path) as fd:
+            compressed_file, filename = utils.encrypt_file(inputfile=fd,
+                                                           filename='foo.txt')
+
+
+class Uncompress_FileTest(TestCase):
+    def test_func(self):
+        inputfile = open(COMPRESSED_FILE, 'rb')
+        fd, filename = utils.uncompress_file(inputfile, 'foo.gz')
+        fd.seek(0)
+        self.assertEqual(fd.read(), b'foo\n')
 
 
 class Create_Spooled_Temporary_FileTest(TestCase):


### PR DESCRIPTION
I move this main functions in utils, I think they will be use for media backup/restore.

I change some aspect of them, now filename is a parameter and functions return a tuple like `(file, filename)`. All is explained in docstrings. It allows dbbackup to be compatible with Python 3 :smile: 

I also changes unit tests for match with this new commit. 