### PR TITLE
add FILENAME_TEMPLATE support in mediabackup

### DIFF
--- a/dbbackup/dbcommands.py
+++ b/dbbackup/dbcommands.py
@@ -14,6 +14,8 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 from dbbackup import settings
 
+from .utils import filename_generate
+
 
 class BaseEngineSettings:
     """Base settings for a database engine"""
@@ -215,21 +217,9 @@ class DBCommands:
         return command
 
     def filename(self, servername=None, wildcard=None):
-        """ Create a new backup filename. """
-        params = {
-            'databasename': self.database['NAME'].replace("/", "_"),
-            'servername': servername or settings.SERVER_NAME,
-            'timestamp': timezone.now(),
-            'extension': self.settings.extension,
-            'wildcard': wildcard,
-        }
-        if callable(settings.FILENAME_TEMPLATE):
-            filename = settings.FILENAME_TEMPLATE(**params)
-        else:
-            params['datetime'] = wildcard or params['timestamp'].strftime(settings.DATE_FORMAT)
-            filename = settings.FILENAME_TEMPLATE.format(**params)
-            filename = filename.replace('--', '-')
-        return filename
+        extension = self.settings.extension
+        return filename_generate(extension, self.settings.database['NAME'],
+                                 servername, wildcard)
 
     def filename_match(self, servername=None, wildcard='*'):
         """ Return the prefix for backup filenames. """

--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -14,11 +14,12 @@ import re
 from django.conf import settings
 from django.core.management.base import CommandError
 
-from dbbackup.management.commands._base import BaseDbBackupCommand
-from dbbackup import utils
-from dbbackup.storage.base import BaseStorage
-from dbbackup.storage.base import StorageError
-from dbbackup import settings as dbbackup_settings
+from ._base import BaseDbBackupCommand
+from ... import utils
+from ...dbcommands import DBCommands
+from ...storage.base import BaseStorage
+from ...storage.base import StorageError
+from ... import settings as dbbackup_settings
 
 
 class Command(BaseDbBackupCommand):
@@ -73,17 +74,11 @@ class Command(BaseDbBackupCommand):
         )
 
     def get_backup_basename(self, **kwargs):
-        # TODO: use DBBACKUP_FILENAME_TEMPLATE
-        server_name = self.get_servername()
-        if server_name:
-            server_name = '-%s' % server_name
 
-        return '%s%s-%s.media.tar%s' % (
-            self.get_databasename(),
-            server_name,
-            datetime.now().strftime(dbbackup_settings.DATE_FORMAT),
-            ('.gz' if kwargs.get('compress') else '')
-        )
+        extension = "tar%s" % ('.gz' if kwargs.get('compress') else '')
+        return utils.filename_generate(extension, "",
+                                       self.get_servername(), wildcard=None,
+                                       filetype='media')
 
     def get_databasename(self):
         # TODO: WTF is this??

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -10,6 +10,7 @@ from django.core import mail
 from django.conf import settings
 
 from .. import utils
+from .. import settings as dbackup_settings
 from .utils import (ENCRYPTED_FILE, clean_gpg_keys, GPG_PRIVATE_PATH,
                     COMPRESSED_FILE)
 
@@ -134,3 +135,12 @@ class Create_Spooled_Temporary_FileTest(TestCase):
 
     def test_func(self, *args):
         utils.create_spooled_temporary_file(filepath=self.path)
+
+
+class Filename_GenerateTest(TestCase):
+    def test_func(self, *args):
+        extension = 'foo'
+        dbackup_settings.SERVER_NAME = 'test'
+        generated_name = utils.filename_generate(extension)
+        self.assertTrue(generated_name.startswith(dbackup_settings.SERVER_NAME))
+        self.assertTrue(generated_name.endswith(extension))


### PR DESCRIPTION
Attempt to add FILENAME_TEMPLATE in mediabackup command. 
Maybe it's redundant, but I pass `filetype` param to new `utils.filename_generate` function. It's pretty usefull for me, because I store `db.gz` and `media.tar.gz` backups in one folder. (Perhaps best approach - create separate MEDIABACKUP_FILENAME_TEMPLATE equal FILENAME_TEMPLATE  by default)
Also I add trick for amazon service (details here https://github.com/django-dbbackup/django-dbbackup/compare/master...pacahon:master#diff-d86981da04b4a0ce99c287e50e270637R93) Maybe usefull to add AMAZON_DELIMITER  params (maybe someone needs this trick on windows platform combined with http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html)
P.S. My tests awkward enough.