### PR TITLE
Remade S3 storage for use django-storage-redux one

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ omit =
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover
+    noqa:
 
     # Don't complain about missing debug-only code:
     def __repr__

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -66,6 +66,7 @@ STORAGE = getattr(settings, 'DBBACKUP_STORAGE', 'dbbackup.storage.filesystem_sto
 BUILTIN_STORAGE = getattr(settings, 'DBBACKUP_BUILTIN_STORAGE', None)
 STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})
 
+# Deprecation
 if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):
     BACKUP_DIRECTORY = STORAGE_OPTIONS['location'] = \
         getattr(settings, 'DBBACKUP_BACKUP_DIRECTORY', os.getcwd())
@@ -74,3 +75,24 @@ if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):
 if hasattr(settings, 'DBBACKUP_FAKE_HOST'):  # noqa
     warnings.warn("DBBACKUP_FAKE_HOST is deprecated, use DBBACKUP_HOSTNAME", DeprecationWarning)
     HOSTNAME = settings.DBBACKUP_FAKE_HOST
+
+UNSED_AWS_SETTINGS = ('DIRECTORY',)
+DEPRECATED_AWS_SETTINGS = (
+    ('BUCKET', 'aws_storage_bucket_name'),
+    ('ACCESS_KEY', 'aws_s3_access_key_id'),
+    ('SECRET_KEY', 'aws_s3_secret_access_key'),
+    ('DOMAIN', 'aws_s3_host'),
+    ('IS_SECURE', 'aws_s3_use_ssl'),
+    ('SERVER_SIDE_ENCRYPTION', 'aws_s3_encryption'),
+)
+if hasattr(settings, 'DBBACKUP_S3_BUCKET'):  # noqa
+    for old_suffix, new_key in DEPRECATED_AWS_SETTINGS:
+        if hasattr(settings, 'DBBACKUP_S3_%s' % old_suffix):
+            STORAGE_OPTIONS[new_key] = getattr(settings, old_suffix)
+            msg = "DBBACKUP_S3_%s is deprecated, use DBBACKUP_STORAGE_OPTIONS['%s']" % (old_suffix, new_key)
+            warnings.warn(msg, DeprecationWarning)
+    for old_suffix in UNSED_AWS_SETTINGS:
+        if hasattr(settings, 'DBBACKUP_S3_%s' % old_suffix):
+            msg = "DBBACKUP_S3_%s is now useless" % old_suffix
+            warnings.warn(msg, DeprecationWarning)
+    del old_suffix, new_key

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -67,7 +67,7 @@ BUILTIN_STORAGE = getattr(settings, 'DBBACKUP_BUILTIN_STORAGE', None)
 STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})
 
 # Deprecation
-if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):
+if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):  # pragma: no cover
     BACKUP_DIRECTORY = STORAGE_OPTIONS['location'] = \
         getattr(settings, 'DBBACKUP_BACKUP_DIRECTORY', os.getcwd())
     warnings.warn("DBBACKUP_BACKUP_DIRECTORY is deprecated, use DBBACKUP_STORAGE_OPTIONS['location']", DeprecationWarning)
@@ -78,14 +78,14 @@ if hasattr(settings, 'DBBACKUP_FAKE_HOST'):  # noqa
 
 UNSED_AWS_SETTINGS = ('DIRECTORY',)
 DEPRECATED_AWS_SETTINGS = (
-    ('BUCKET', 'aws_storage_bucket_name'),
-    ('ACCESS_KEY', 'aws_s3_access_key_id'),
-    ('SECRET_KEY', 'aws_s3_secret_access_key'),
-    ('DOMAIN', 'aws_s3_host'),
-    ('IS_SECURE', 'aws_s3_use_ssl'),
-    ('SERVER_SIDE_ENCRYPTION', 'aws_s3_encryption'),
+    ('BUCKET', 'bucket_name'),
+    ('ACCESS_KEY', 'access_key'),
+    ('SECRET_KEY', 'secret_key'),
+    ('DOMAIN', 'host'),
+    ('IS_SECURE', 'use_ssl'),
+    ('SERVER_SIDE_ENCRYPTION', 'encryption'),
 )
-if hasattr(settings, 'DBBACKUP_S3_BUCKET'):  # noqa
+if hasattr(settings, 'DBBACKUP_S3_BUCKET'):  # pragma: no cover
     for old_suffix, new_key in DEPRECATED_AWS_SETTINGS:
         if hasattr(settings, 'DBBACKUP_S3_%s' % old_suffix):
             STORAGE_OPTIONS[new_key] = getattr(settings, old_suffix)

--- a/dbbackup/storage/builtin_django.py
+++ b/dbbackup/storage/builtin_django.py
@@ -27,7 +27,7 @@ class Storage(BaseStorage):
         self.storage.delete(name=filepath)
 
     def list_directory(self):
-        return self.storage.listdir(path='')[1]
+        return self.storage.listdir('')[1]
 
     def write_file(self, filehandle, filename):
         self.storage.save(name=filename, content=filehandle)

--- a/dbbackup/storage/s3_storage.py
+++ b/dbbackup/storage/s3_storage.py
@@ -3,7 +3,6 @@ S3 Storage object.
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from .. import settings
 from .base import StorageError
 from .builtin_django import Storage as DjangoStorage
 
@@ -12,18 +11,16 @@ STORAGE_PATH = 'storages.backends.s3boto.S3BotoStorage'
 
 class Storage(DjangoStorage):
     """Filesystem API Storage."""
-
     def __init__(self, server_name=None, **options):
         self.name = 'AmazonS3'
         self._check_filesystem_errors(options)
         super(Storage, self).__init__(storage_path=STORAGE_PATH,
-                                      bucket=options['aws_storage_bucket_name'],
+                                      bucket=options['bucket_name'],
                                       **options)
 
     def _check_filesystem_errors(self, options):
         """Check we have all the required settings defined."""
-        required_args = ('aws_storage_bucket_name', 'aws_s3_access_key_id',
-                         'aws_s3_secret_access_key')
+        required_args = ('bucket_name', 'access_key', 'secret_key')
         err_msg = "%s storage requires settings.DBBACKUP_STORAGE_OPTIONS['%s'] to be define"
         for arg in required_args:
             if arg not in options:

--- a/dbbackup/storage/s3_storage.py
+++ b/dbbackup/storage/s3_storage.py
@@ -3,80 +3,28 @@ S3 Storage object.
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-import os
-from boto.s3.key import Key
-from boto.s3.connection import S3Connection
-from io import BytesIO
-from django.conf import settings
-from tempfile import SpooledTemporaryFile
-from .base import BaseStorage, StorageError
+from .. import settings
+from .base import StorageError
+from .builtin_django import Storage as DjangoStorage
+
+STORAGE_PATH = 'storages.backends.s3boto.S3BotoStorage'
 
 
-class Storage(BaseStorage):
-    """ S3 API Storage. """
-    S3_BUCKET = getattr(settings, 'DBBACKUP_S3_BUCKET', None)
-    S3_ACCESS_KEY = getattr(settings, 'DBBACKUP_S3_ACCESS_KEY', None)
-    S3_SECRET_KEY = getattr(settings, 'DBBACKUP_S3_SECRET_KEY', None)
-    S3_DOMAIN = getattr(settings, 'DBBACKUP_S3_DOMAIN', 's3.amazonaws.com')
-    S3_IS_SECURE = getattr(settings, 'DBBACKUP_S3_USE_SSL', True)
-    S3_DIRECTORY = getattr(settings, 'DBBACKUP_S3_DIRECTORY', "django-dbbackups/")
-    S3_SERVER_SIDE_ENCRYPTION = getattr(settings, 'DBBACKUP_S3_SERVER_SIDE_ENCRYPTION', False)
-    if S3_DIRECTORY:
-        S3_DIRECTORY = '%s/' % S3_DIRECTORY.strip('/')
+class Storage(DjangoStorage):
+    """Filesystem API Storage."""
 
-    def __init__(self, server_name=None):
-        self._check_filesystem_errors()
+    def __init__(self, server_name=None, **options):
         self.name = 'AmazonS3'
-        self.conn = S3Connection(aws_access_key_id=self.S3_ACCESS_KEY,
-            aws_secret_access_key=self.S3_SECRET_KEY, host=self.S3_DOMAIN,
-            is_secure=self.S3_IS_SECURE)
-        self.bucket = self.conn.get_bucket(self.S3_BUCKET)
-        BaseStorage.__init__(self)
+        self._check_filesystem_errors(options)
+        super(Storage, self).__init__(storage_path=STORAGE_PATH,
+                                      bucket=options['aws_storage_bucket_name'],
+                                      **options)
 
-    def _check_filesystem_errors(self):
-        if not self.S3_BUCKET:
-            raise StorageError('Filesystem storage requires DBBACKUP_S3_BUCKET to be defined in settings.')
-        if not self.S3_ACCESS_KEY:
-            raise StorageError('Filesystem storage requires DBBACKUP_S3_ACCESS_KEY to be defined in settings.')
-        if not self.S3_SECRET_KEY:
-            raise StorageError('Filesystem storage requires DBBACKUP_S3_SECRET_KEY to be defined in settings.')
-
-    @property
-    def backup_dir(self):
-        return self.S3_DIRECTORY
-
-    def delete_file(self, filepath):
-        self.bucket.delete_key(filepath)
-
-    def list_directory(self):
-        return [k.name for k in self.bucket.list(prefix=self.S3_DIRECTORY)]
-
-    def write_file(self, filehandle, filename):
-        # Use multipart upload because normal upload maximum is 5 GB.
-        filepath = os.path.join(self.S3_DIRECTORY, filename)
-        filehandle.seek(0)
-        handle = self.bucket.initiate_multipart_upload(filepath,
-            encrypt_key=self.S3_SERVER_SIDE_ENCRYPTION)
-        try:
-            chunk = 1
-            while True:
-                chunkdata = filehandle.read(5 * 1024 * 1024)
-                if not chunkdata:
-                    break
-                tmpfile = BytesIO(chunkdata)
-                tmpfile.seek(0)
-                handle.upload_part_from_file(tmpfile, chunk)
-                tmpfile.close()
-                chunk += 1
-            handle.complete_upload()
-        except Exception:
-            handle.cancel_upload()
-            raise
-
-    def read_file(self, filepath):
-        """ Read the specified file and return it's handle. """
-        key = Key(self.bucket)
-        key.key = filepath
-        filehandle = SpooledTemporaryFile(max_size=10 * 1024 * 1024)
-        key.get_contents_to_file(filehandle)
-        return filehandle
+    def _check_filesystem_errors(self, options):
+        """Check we have all the required settings defined."""
+        required_args = ('aws_storage_bucket_name', 'aws_s3_access_key_id',
+                         'aws_s3_secret_access_key')
+        err_msg = "%s storage requires settings.DBBACKUP_STORAGE_OPTIONS['%s'] to be define"
+        for arg in required_args:
+            if arg not in options:
+                raise StorageError(err_msg % (self.name, arg))

--- a/dbbackup/tests/storages/test_s3.py
+++ b/dbbackup/tests/storages/test_s3.py
@@ -20,9 +20,9 @@ if mock_s3 is None:
 @mock_s3
 class S3StorageTest(TestCase):
     def setUp(self):
-        self.storage = S3Storage(aws_storage_bucket_name='foo_bucket',
-                                 aws_s3_access_key_id='foo_id',
-                                 aws_s3_secret_access_key='foo_secret')
+        self.storage = S3Storage(bucket_name='foo_bucket',
+                                 access_key='foo_id',
+                                 secret_key='foo_secret')
         self.conn = boto.connect_s3()
         self.bucket = self.conn.create_bucket('foo_bucket')
         key = boto.s3.key.Key(self.bucket)

--- a/dbbackup/tests/storages/test_s3.py
+++ b/dbbackup/tests/storages/test_s3.py
@@ -1,0 +1,62 @@
+from io import BytesIO
+from django.test import TestCase
+import boto
+try:
+    from moto import mock_s3
+except SyntaxError:
+    mock_s3 = None
+from dbbackup.storage.s3_storage import Storage as S3Storage
+from dbbackup.storage.base import StorageError
+from dbbackup.tests.utils import skip_py3
+
+
+# Python 3.2 fix
+if mock_s3 is None:
+    def mock_s3(obj):
+        return obj
+
+
+@skip_py3
+@mock_s3
+class S3StorageTest(TestCase):
+    def setUp(self):
+        self.storage = S3Storage(aws_storage_bucket_name='foo_bucket',
+                                 aws_s3_access_key_id='foo_id',
+                                 aws_s3_secret_access_key='foo_secret')
+        self.conn = boto.connect_s3()
+        self.bucket = self.conn.create_bucket('foo_bucket')
+        key = boto.s3.key.Key(self.bucket)
+        key.key = 'foo_file'
+        key.set_contents_from_string('bar')
+
+    def test_delete_file(self):
+        self.storage.delete_file('foo_file')
+        self.assertEqual(0, len(self.bucket.get_all_keys()))
+
+    def test_list_directory(self):
+        files = self.storage.list_directory()
+        self.assertEqual(len(files), 1)
+
+    def test_write_file(self):
+        self.storage.write_file(BytesIO(b'bar'), 'foo')
+        self.assertEqual(2, len(self.bucket.get_all_keys()))
+        key = self.bucket.get_key('foo')
+        self.assertEqual('bar', key.get_contents_as_string())
+
+    def test_read_file(self):
+        read_file = self.storage.read_file('foo_file')
+        self.assertEqual(read_file.read(), b'bar')
+
+    def test_check(self):
+        with self.assertRaises(StorageError):
+            self.storage._check_filesystem_errors({
+                'aws_storage_bucket_name': '', 'aws_s3_access_key_id': ''})
+        with self.assertRaises(StorageError):
+            self.storage._check_filesystem_errors({
+                'aws_storage_bucket_name': '', 'aws_s3_secret_access_key': ''})
+        with self.assertRaises(StorageError):
+            self.storage._check_filesystem_errors({
+                'aws_s3_access_key_id': '', 'aws_s3_secret_access_key': ''})
+        self.storage._check_filesystem_errors({
+            'aws_storage_bucket_name': '', 'aws_s3_access_key_id': '',
+            'aws_s3_secret_access_key': ''})

--- a/dbbackup/tests/storages/test_s3.py
+++ b/dbbackup/tests/storages/test_s3.py
@@ -16,13 +16,14 @@ if mock_s3 is None:
         return obj
 
 
-@skip_py3
 @mock_s3
+@skip_py3
 class S3StorageTest(TestCase):
     def setUp(self):
         self.storage = S3Storage(bucket_name='foo_bucket',
                                  access_key='foo_id',
                                  secret_key='foo_secret')
+        # Create fixtures
         self.conn = boto.connect_s3()
         self.bucket = self.conn.create_bucket('foo_bucket')
         key = boto.s3.key.Key(self.bucket)
@@ -50,13 +51,12 @@ class S3StorageTest(TestCase):
     def test_check(self):
         with self.assertRaises(StorageError):
             self.storage._check_filesystem_errors({
-                'aws_storage_bucket_name': '', 'aws_s3_access_key_id': ''})
+                'bucket_name': '', 'access_key': ''})
         with self.assertRaises(StorageError):
             self.storage._check_filesystem_errors({
-                'aws_storage_bucket_name': '', 'aws_s3_secret_access_key': ''})
+                'bucket_name': '', 'secret_key': ''})
         with self.assertRaises(StorageError):
             self.storage._check_filesystem_errors({
-                'aws_s3_access_key_id': '', 'aws_s3_secret_access_key': ''})
+                'access_key': '', 'secret_key': ''})
         self.storage._check_filesystem_errors({
-            'aws_storage_bucket_name': '', 'aws_s3_access_key_id': '',
-            'aws_s3_secret_access_key': ''})
+            'bucket_name': '', 'access_key': '', 'secret_key': ''})

--- a/dbbackup/tests/utils.py
+++ b/dbbackup/tests/utils.py
@@ -74,7 +74,9 @@ def clean_gpg_keys():
         pass
 
 
-def skip_py3(testcase):
+def skip_py3(testcase, reason="Not in Python 3"):
+    """Decorator for skip Python 3 tests."""
     if six.PY3:
-        setup = lambda s: s.skipTest('')
+        setup = lambda s: s.skipTest(reason)
         testcase.setUp = setup
+    return testcase

--- a/dbbackup/tests/utils.py
+++ b/dbbackup/tests/utils.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     from io import StringIO
 from django.conf import settings
+from django.utils import six
 from dbbackup.storage.base import BaseStorage
 
 BASE_FILE = os.path.join(settings.BASE_DIR, 'tests/test.txt')
@@ -61,13 +62,19 @@ Storage = FakeStorage
 
 
 def clean_gpg_keys():
-        try:
-            cmd = ("gpg --batch --yes --delete-key '%s'" % GPG_FINGERPRINT)
-            subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
-        except:
-            pass
-        try:
-            cmd = ("gpg --batch --yes --delete-secrect-key '%s'" % GPG_FINGERPRINT)
-            subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
-        except:
-            pass
+    try:
+        cmd = ("gpg --batch --yes --delete-key '%s'" % GPG_FINGERPRINT)
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+    except:
+        pass
+    try:
+        cmd = ("gpg --batch --yes --delete-secrect-key '%s'" % GPG_FINGERPRINT)
+        subprocess.call(cmd, stdout=DEV_NULL, stderr=DEV_NULL)
+    except:
+        pass
+
+
+def skip_py3(testcase):
+    if six.PY3:
+        setup = lambda s: s.skipTest('')
+        testcase.setUp = setup

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -1,77 +1,155 @@
 Remote storage
 ==============
 
-django-dbbackup comes with a variety of remote storage options. If you wish
-to build your own, extend ``dbbackup.storage.base.BaseStorage`` and point 
-your ``settings.DBBACKUP_STORAGE`` to ``'my_storage.backend.ClassName'``.
+django-dbbackup comes with a variety of remote storage options and it can deal
+with Django Storage API for extend its possibilities.
+
+You can choose your storage backend by set ``settings.DBBACKUP_STORAGE``,
+it must point to module containing the chosen Storage class. For example:
+``dbbackup.storage.filesystem_storage`` for use file system storage.
+Below, we'll list some of the available solutions and their options.
+
+Storage's option are gathered in ``settings.DBBACKUP_STORAGE_OPTIONS`` which
+is a dictionary of keywords representing how to configure it.
+
+.. note::
+
+    A lot of changes has been made for use Django Storage API as primary source of
+    backends and due to this task, some settings has been deprecated but always
+    functionnal until removing. Please take care of notes and warnings in this
+    documentation and at your project's launching.
+
+.. warning::
+
+    Do not configure backup storage with the same configuration than your media
+    files, you'll risk to share backups inside public directories.
 
 Local disk
 ----------
 
-To store your database backups on the local filesystem, simply setup the
-required settings below. Storing backups to local disk may also be
-useful for Dropbox if you already have the offical Dropbox client
-installed on your system.
+Dbbackup uses `built-in file system storage`_ to manage files on a local
+directory.
+
+.. _`built-in file system storage`: https://docs.djangoproject.com/en/1.8/ref/files/storage/#the-filesystemstorage-class
+
+.. note::
+
+    Storing backups to local disk may also be useful for Dropbox if you
+    already have the offical Dropbox client installed on your system.
+
+Setup
+~~~~~
+
+To store your backups on the local file system, simply setup the
+required settings below.
+
+::
+
+    DBBACKUP_STORAGE = 'dbbackup.storage.filesystem_storage'
+    DBBACKUP_STORAGE_OPTIONS = {'location': '/my/backup/dir/'}
+
 
 
 Available Settings
 ~~~~~~~~~~~~~~~~~~
 
-**DBBACKUP\_BACKUP\_DIRECTORY (optional)** - The directory on your local
-system you wish to save your backups. Default: Current working
-directory.
+**location** - Default: Current working directory (``os.getcwd``)
+
+Absolute path to the directory that will hold the files.
+
+.. warning::
+
+    ``settings.DBBACKUP_BACKUP_DIRECTORY`` was used before but is deprecated.
+    Backup location must no be in ``settings.MEDIA_ROOT``, it will raise an
+    ``StorageError`` if ``settings.DEBUG`` is ``False`` else a warning.
+
+**file_permissions_mode** - Default: ``settings.FILE_UPLOAD_PERMISSIONS``
+
+The file system permissions that the file will receive when it is saved. 
 
 
 Amazon S3
 ---------
 
+Our S3 backend uses Django Storage Redux which it uses `boto`_.
+
+.. _`boto`: http://docs.pythonboto.org/en/latest/#
+
+Setup
+~~~~~
+
 In order to backup to Amazon S3, you'll first need to create an Amazon
 Webservices Account and setup your Amazon S3 bucket. Once that is
 complete, you can follow the required setup below.
 
-Setup Your Django Project
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
 ::
 
-    pip install boto
+    pip install boto django-storage-redux
 
 Add the following to your project's settings:
 
 ::
 
     DBBACKUP_STORAGE = 'dbbackup.storage.s3_storage'
-    DBBACKUP_S3_BUCKET = '<amazon_bucket_name>'
-    DBBACKUP_S3_ACCESS_KEY = '<amazon_access_key>'
-    DBBACKUP_S3_SECRET_KEY = '<amazon_secret_key>'
-
+    DBBACKUP_STORAGE_OPTIONS = {
+        'access_key': 'my_id',
+        'secret_key': 'my_secret',
+        'bucket_name': 'my_bucket_name'
+    }
 
 Available Settings
 ~~~~~~~~~~~~~~~~~~
 
-**DBBACKUP\_S3\_BUCKET (required)** - The name of the Amazon S3 bucket
-to store your backups. This directory must exist before attempting to
-create your first backup.
+.. note::
 
-**DBBACKUP\_S3\_ACCESS\_KEY (required)** - Your Amazon Account Access
-Key. This can be found on your Amazon Account Security Credentials page.
-Note: Do not share this key with anyone you do not trust with access to
-your Amazon files.
+    More settings are available but without clear official documentation about
+    it, you can refer to `source code`_ and look at ``S3BotoStorage``'s
+    attributes.
 
-**DBBACKUP\_S3\_SECRET\_KEY (required)** - Your Amazon Account Secret
-Key. This can be found in the same location as your Access Key above.
+.. _`source code`: https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto.py#L204
 
-**DBBACKUP\_S3\_DIRECTORY (optional)** - The directory in your Amazon S3
-bucket you wish to save your backups. By default this is set to
-'django-dbbackups/'.
+**access_key** - Required
 
-**DBBACKUP\_S3\_DOMAIN (optional)** - Specify the Amazon domain to use
-when transferring the generated backup files. For example, this can be
-set to 's3-eu-west-1.amazonaws.com'. By default, this is
-'s3.amazonaws.com'.
+Your AWS access key as string. This can be found on your `Amazon Account
+Security Credentials page`_.
 
-**DBBACKUP\_S3\_IS\_SECURE (optional)** - Set False to disable using
-SSL. Default is True.
+.. _`Amazon Account Security Credentials page`: https://console.aws.amazon.com/iam/home#security_credential
+
+.. note::
+
+    ``settings.DBBACKUP_S3_ACCESS_KEY`` was used before but is deprecated.
+
+**secret_key** - Required
+
+Your Amazon Web Services secret access key, as a string.
+
+.. note::
+
+    ``settings.DBBACKUP_S3_SECRET_KEY`` was used before but is deprecated.
+
+**bucket_name** - Required
+
+Your Amazon Web Services storage bucket name, as a string. This directory must
+exist before attempting to create your first backup.
+
+.. note::
+
+    ``settings.DBBACKUP_S3_BUCKET`` was used before but is deprecated.
+
+**host** - Default: ``'s3.amazonaws.com'`` (``boto.s3.connection.S3Connection.DefaultHost``)
+
+Specify the Amazon domain to use when transferring the generated backup files.
+For example, this can be set to ``'s3-eu-west-1.amazonaws.com'``.
+
+.. note::
+
+    ``settings.DBBACKUP_S3_DOMAIN`` was used before but is deprecated.
+
+**use_ssl** - Default: ``True``
+
+.. note::
+
+    ``settings.DBBACKUP_S3_IS_SECURE`` was used before but is deprecated.
 
 Dropbox
 -------
@@ -119,6 +197,15 @@ setup the required settings below.
 Setup Your Django Project
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+    This storage will be updated for use Django Storage's one.
+
+.. warning::
+
+    This storage doesn't use private connection for communcation, don't use it
+    if you're not sure about the link between client and server.
+
 Using FTP does not require any external libraries to be installed, simply
 use the below project settings:
 
@@ -130,30 +217,43 @@ use the below project settings:
     DBBACKUP_FTP_PASSWORD = 'password, can be blank'
     DBBACKUP_FTP_PATH = 'path, blank for default'
 
-
 Available Settings
 ~~~~~~~~~~~~~~~~~~
 
-**DBBACKUP\_FTP\_HOST (required)** - Hostname for the server you wish to
-save your backups.
+**DBBACKUP\_FTP\_HOST** -  Required
 
-**DBBACKUP\_FTP\_USER, DBBACKUP\_FTP\_PASSWORD** - FTP authorization
-credentionals. Skip for anonymous FTP.
+Hostname for the server you wish to save your backups.
 
-**DBBACKUP\_FTP\_PATH** - The directory on remote FTP server you wish to
-save your backups.
+**DBBACKUP\_FTP\_USER** - Default: ``None``
+
+Authentication login, do not use if anonymous.
+
+**DBBACKUP\_FTP\_PASSWORD** - Default: ``None``
+
+Authentication password, do not use if there's no password.
+
+**DBBACKUP\_FTP\_PATH** - Default: ``'.'``
+
+The directory on remote FTP server you wish to save your backups.
+
+.. note::
+
+    As other updated storages, this settings will be deprecated in favor of
+    dictionary ``settings.DBBACKUP_STORAGE_OPTIONS``.
 
 Django built-in storage API
 ---------------------------
 
 Django has its own storage API for managing media files. Dbbackup allows
-you to use (third-party) Django storage backends. The default backend is
+you to use (third-part) Django storage backends. The default backend is
 ``FileSystemStorage``, which is integrated in Django but we invite you
 to take a look at `django-storages-redux`_ which has a great collection of
 storage backends.
 
-Django project settings
-~~~~~~~~~~~~~~~~~~~~~~~
+.. _django-storages-redux: https://github.com/jschneier/django-storages
+
+Setup using built-in storage API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use Django's built-in `FileSystemStorage`_, add the following lines to
 your ``settings.py``::
@@ -163,17 +263,33 @@ your ``settings.py``::
     # DBBACKUP_DJANGO_STORAGE = 'django.core.file.storages.FileSystemStorage'
     DBBACKUP_STORAGE_OPTIONS = {'location': '/mybackupdir/'}
 
-Available Settings
-~~~~~~~~~~~~~~~~~~
-
-**DBBACKUP_DJANGO_STORAGE** - Path to a Django Storage class (in Python dot style).
-
-.. warning ::
-
-    Do not use a Django storage backend without configuring its options, otherwise you will risk mixing media files (with public access) and backups (strictly private).
-
-**DBBACKUP_STORAGE_OPTIONS** - Dictionary used to instantiate a Django Storage class. The ``location`` key customizes the directory for ``FileSystemStorage``.
-
-.. _django-storages-redux: https://github.com/jschneier/django-storages
 .. _FileSystemStorage: https://docs.djangoproject.com/en/1.8/ref/files/storage/#the-filesystemstorage-class
 
+``'dbbackup.storage.builtin_django'`` is a wrapper for use the Django storage
+defined in ``DBBACKUP_DJANGO_STORAGE`` with the options defined in 
+``DBBACKUP_STORAGE_OPTIONS``.
+
+Used settings
+~~~~~~~~~~~~~
+
+**DBBACKUP_DJANGO_STORAGE** - Default: ``'django.core.file.storages.FileSystemStorage'``
+
+Path to a Django Storage class (in Python dot style).
+
+.. warning::
+
+    Do not use a Django storage backend without configuring its options,
+    otherwise you will risk mixing media files (with public access) and
+    backups (strictly private).
+
+**DBBACKUP_STORAGE_OPTIONS** - Default: ``{}``
+
+Dictionary used to instantiate a Django Storage class. For example, the
+``location`` key customizes the directory for ``FileSystemStorage``.
+
+Write your custom storage
+-------------------------
+
+If you wish to build your own, extend ``dbbackup.storage.base.BaseStorage``
+and point your ``settings.DBBACKUP_STORAGE`` to
+``'my_storage.backend.ClassName'``.

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,3 +3,6 @@ flake8
 mock
 coverage
 python-gnupg
+django-storages-redux
+boto
+moto


### PR DESCRIPTION
As Django Storage Redux (https://github.com/jschneier/django-storages) has already a boto S3 storage, I drop our code without remove it the storage class:
- For use it, there's now django-storage-redux and boto as requirements
- Settings are adapted to django-storage-redux, but old ones are usable
- Tests are made with moto
- Documentation updated