### PR TITLE
Started using the noinput option for dbrestore

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -47,6 +47,7 @@ class Command(BaseDbBackupCommand):
             self.decrypt = options.get('decrypt')
             self.uncompress = options.get('uncompress')
             self.passphrase = options.get('passphrase')
+            self.interactive = options.get('interactive')
             self.database = self._get_database(options)
             self.storage = BaseStorage.storage_factory()
             self.dbcommands = DBCommands(self.database)
@@ -92,10 +93,11 @@ class Command(BaseDbBackupCommand):
             inputfile.close()
             inputfile = uncompressed_file
         self.log("  Restore tempfile created: %s" % utils.handle_size(inputfile), 1)
-        answer = input("Are you sure you want to continue? [Y/n]")
-        if answer.lower() not in ('y', 'yes', ''):
-            self.log("Quitting", 1)
-            sys.exit(0)
+        if self.interactive:
+            answer = input("Are you sure you want to continue? [Y/n]")
+            if answer.lower() not in ('y', 'yes', ''):
+                self.log("Quitting", 1)
+                sys.exit(0)
         inputfile.seek(0)
         self.dbcommands.run_restore_commands(inputfile)
 

--- a/dbbackup/tests/commands/test_dbrestore.py
+++ b/dbbackup/tests/commands/test_dbrestore.py
@@ -27,6 +27,7 @@ class DbrestoreCommandRestoreBackupTest(TestCase):
         self.command.database = TEST_DATABASE
         self.command.dbcommands = DBCommands(TEST_DATABASE)
         self.command.passphrase = None
+        self.command.interactive = True
         self.command.storage = FakeStorage()
         HANDLED_FILES.clean()
         cmd = ('gpg --import %s' % GPG_PRIVATE_PATH).split()


### PR DESCRIPTION
I realised the `--noinput` argument was not being used, so i added it so that users can bypass the yes or no question.

Found this to be important when i was configuring docker and wanted to automatically restore my database without user input.