### PR TITLE
Fix missing requirements file for install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include requirements-tests.txt


### PR DESCRIPTION
Latest release doesn't work:

``` 
Downloading/unpacking django-dbbackup==2.3.1 (from -r requirements.txt (line 11))
  Downloading django-dbbackup-2.3.1.tar.gz
  Running setup.py egg_info for package django-dbbackup
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/home/ubuntu/virtualenvs/venv-2.7.9/build/django-dbbackup/setup.py", line 21, in <module>
        tests_require=get_test_requirements(),
      File "/home/ubuntu/virtualenvs/venv-2.7.9/build/django-dbbackup/setup.py", line 11, in get_test_requirements
        return open('requirements-tests.txt').read().splitlines()
    IOError: [Errno 2] No such file or directory: 'requirements-tests.txt'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/home/ubuntu/virtualenvs/venv-2.7.9/build/django-dbbackup/setup.py", line 21, in <module>

    tests_require=get_test_requirements(),

  File "/home/ubuntu/virtualenvs/venv-2.7.9/build/django-dbbackup/setup.py", line 11, in get_test_requirements

    return open('requirements-tests.txt').read().splitlines()

IOError: [Errno 2] No such file or directory: 'requirements-tests.txt'
```