### PR TITLE
Fix doc for DBBACKUP_HOSTNAME to match code

### DIFF
--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -38,7 +38,7 @@ class Command(BaseDbBackupCommand):
     def handle(self, *args, **options):
         self.encrypt = options.get('encrypt')
         self.compress = not options.get('no_compress')
-        self.servername = options.get('servername') or settings.HOSTNAME
+        self.servername = options.get('servername') or settings.DBBACKUP_HOSTNAME
         try:
             self.storage = BaseStorage.storage_factory()
             self.backup_mediafiles(self.encrypt, self.compress)

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 DATABASES = getattr(settings, 'DBBACKUP_DATABASES', list(settings.DATABASES.keys()))
 
 # Fake host
-HOSTNAME = getattr(settings, 'DBBACKUP_HOSTNAME', socket.gethostname())
+DBBACKUP_HOSTNAME = getattr(settings, 'DBBACKUP_HOSTNAME', socket.gethostname())
 
 # Directory to use for temporary files
 TMP_DIR = getattr(settings, 'DBBACKUP_TMP_DIR', tempfile.gettempdir())
@@ -82,7 +82,7 @@ if hasattr(settings, 'DBBACKUP_BACKUP_DIRECTORY'):  # pragma: no cover
 
 if hasattr(settings, 'DBBACKUP_FAKE_HOST'):  # pragma: no cover
     warnings.warn("DBBACKUP_FAKE_HOST is deprecated, use DBBACKUP_HOSTNAME", DeprecationWarning)
-    HOSTNAME = settings.DBBACKUP_FAKE_HOST
+    DBBACKUP_HOSTNAME = settings.DBBACKUP_FAKE_HOST
 
 UNSED_AWS_SETTINGS = ('DIRECTORY',)
 DEPRECATED_AWS_SETTINGS = (

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -193,7 +193,7 @@ class Filename_To_DateTest(TestCase):
         datestring = utils.filename_to_date(filename)
 
 
-@patch('dbbackup.settings.HOSTNAME', 'test')
+@patch('dbbackup.settings.DBBACKUP_HOSTNAME', 'test')
 class Filename_GenerateTest(TestCase):
     @patch('dbbackup.settings.FILENAME_TEMPLATE', '---{databasename}--{servername}-{datetime}.{extension}')
     def test_func(self, *args):
@@ -205,13 +205,13 @@ class Filename_GenerateTest(TestCase):
     def test_db(self, *args):
         extension = 'foo'
         generated_name = utils.filename_generate(extension)
-        self.assertTrue(generated_name.startswith(dbbackup_settings.HOSTNAME))
+        self.assertTrue(generated_name.startswith(dbbackup_settings.DBBACKUP_HOSTNAME))
         self.assertTrue(generated_name.endswith(extension))
 
     def test_media(self, *args):
         extension = 'foo'
         generated_name = utils.filename_generate(extension, content_type='media')
-        self.assertTrue(generated_name.startswith(dbbackup_settings.HOSTNAME))
+        self.assertTrue(generated_name.startswith(dbbackup_settings.DBBACKUP_HOSTNAME))
         self.assertTrue(generated_name.endswith(extension))
 
     @patch('dbbackup.settings.FILENAME_TEMPLATE', callable_for_filename_template)

--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -23,7 +23,7 @@ input = raw_input if six.PY2 else input  # noqa
 FAKE_HTTP_REQUEST = HttpRequest()
 FAKE_HTTP_REQUEST.META['SERVER_NAME'] = ''
 FAKE_HTTP_REQUEST.META['SERVER_PORT'] = ''
-FAKE_HTTP_REQUEST.META['HTTP_HOST'] = settings.HOSTNAME
+FAKE_HTTP_REQUEST.META['HTTP_HOST'] = settings.DBBACKUP_HOSTNAME
 FAKE_HTTP_REQUEST.path = '/DJANGO-DBBACKUP-EXCEPTION'
 
 BYTES = (
@@ -382,7 +382,7 @@ def filename_generate(extension, database_name='', servername=None, content_type
     :param database_name: If it is database backup specify its name
     :type database_name: ``str``
 
-    :param servername: Specify server name or by default ``settings.HOSTNAME``
+    :param servername: Specify server name or by default ``settings.DBBACKUP_HOSTNAME``
     :type servername: ``str``
 
     :param content_type: Content type to backup, ``'media'`` or ``'db'``
@@ -400,7 +400,7 @@ def filename_generate(extension, database_name='', servername=None, content_type
         if '.' in database_name:
             database_name = database_name.split('.')[0]
     params = {
-        'servername': servername or settings.HOSTNAME,
+        'servername': servername or settings.DBBACKUP_HOSTNAME,
         'datetime': wildcard or timezone.now().strftime(settings.DATE_FORMAT),
         'databasename': database_name,
         'extension': extension,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -112,12 +112,12 @@ exception is received.
 
 Default: ``True``
 
-HOSTNAME
-~~~~~~~~
+DBBACKUP_HOSTNAME
+~~~~~~~~~~~~~~~~~
 
 Hostname needed by django-dbbackup's uncaught exception email sender for
 well described error reporting. If you are using ``ALLOWED_HOSTS`` you should
-set ``HOSTNAME`` to any host from ``ALLOWED_HOSTS`` setting. Otherwise
+set ``DBBACKUP_HOSTNAME`` to any host from ``ALLOWED_HOSTS`` setting. Otherwise
 django-dbbackup can not send email to the ``SERVER_EMAIL``.
 
 Default: ``socket.gethostname()``


### PR DESCRIPTION
The code in dbbackup.settings looks for a Django setting named
DBBACKUP_HOSTNAME, but the documentation says to set HOSTNAME. This
mistake probably happened because inside dbbackup, the setting is
refered to as HOSTNAME.

Changes:

* Update doc to say DBBACKUP_HOSTNAME is the setting
* Change code to consistently refer to this setting as DBBACKUP_HOSTNAME