### PR TITLE
#152 | NameError: name 'warnings' is not defined.

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division,
 
 import os
 import sys
+import warnings
 from optparse import make_option
 
 from django.conf import settings


### PR DESCRIPTION
Fix for #152.