### PR TITLE
Added mediarestore command

### DIFF
--- a/dbbackup/management/commands/_base.py
+++ b/dbbackup/management/commands/_base.py
@@ -6,8 +6,10 @@ from logging import getLogger
 from optparse import make_option
 from shutil import copyfileobj
 
-from django.core.management.base import BaseCommand, LabelCommand
+from django.core.management.base import BaseCommand, LabelCommand, CommandError
 from django.utils import six
+
+from ...storage.base import StorageError
 
 input = raw_input if six.PY2 else input  # @ReservedAssignment
 
@@ -32,18 +34,62 @@ class BaseDbBackupCommand(LabelCommand):
         self.logger.setLevel(level)
 
     def _ask_confirmation(self):
-        answer = input("Are you sure you want to continue? [Y/n]")
+        answer = input("Are you sure you want to continue? [Y/n] ")
         if answer.lower().startswith('n'):
             self.logger.info("Quitting")
             sys.exit(0)
+
+    def read_from_storage(self, path):
+        return self.storage.read_file(path)
+
+    def write_to_storage(self, file, path):
+        self.logger.info("Writing file to %s: %s, filename: %s",
+                         self.storage.name, self.storage.backup_dir,
+                         path)
+        self.storage.write_file(file, path)
 
     def read_local_file(self, path):
         """Open file in read mode on local filesystem."""
         return open(path, 'rb')
 
-    # TODO: Define chunk size
     def write_local_file(self, outputfile, path):
         """Write file to the desired path."""
+        self.logger.info("Writing file to %s", path)
         outputfile.seek(0)
         with open(path, 'wb') as fd:
             copyfileobj(outputfile, fd)
+
+    def _get_backup_file(self):
+        if self.path:
+            input_filename = self.path
+            input_file = self.read_local_file(self.path)
+        else:
+            if self.filename:
+                input_filename = self.filename
+            # Fetch the latest backup if filepath not specified
+            else:
+                self.logger.info("Finding latest backup")
+                # database = self.database['NAME'] if self.content_type == 'db' else None
+                try:
+                    input_filename = self.storage.get_latest_backup(
+                        encrypted=self.decrypt,
+                        compressed=self.uncompress,
+                        content_type=self.content_type)
+                        # TODO: Make better filter
+                        # database=database)
+                except StorageError as err:
+                    raise CommandError(err.args[0])
+            input_file = self.read_from_storage(input_filename)
+        return input_filename, input_file
+
+    def _cleanup_old_backups(self):
+        """
+        Cleanup old backups, keeping the number of backups specified by
+        DBBACKUP_CLEANUP_KEEP and any backups that occur on first of the month.
+        """
+        # database = self.database if self.content_type == 'db' else None
+        file_list = self.storage.clean_old_backups(encrypted=self.encrypt,
+                                                   compressed=self.compress,
+                                                   content_type=self.content_type)
+                                                   # TODO: Make better filter
+                                                   # database=database)

--- a/dbbackup/management/commands/_base.py
+++ b/dbbackup/management/commands/_base.py
@@ -1,9 +1,15 @@
 """
 Abstract Command.
 """
+import sys
 from logging import getLogger
 from optparse import make_option
+from shutil import copyfileobj
+
 from django.core.management.base import BaseCommand, LabelCommand
+from django.utils import six
+
+input = raw_input if six.PY2 else input  # @ReservedAssignment
 
 
 class BaseDbBackupCommand(LabelCommand):
@@ -24,3 +30,20 @@ class BaseDbBackupCommand(LabelCommand):
     def _set_logger_level(self):
         level = 60 if self.quiet else (self.verbosity + 1) * 10
         self.logger.setLevel(level)
+
+    def _ask_confirmation(self):
+        answer = input("Are you sure you want to continue? [Y/n]")
+        if answer.lower().startswith('n'):
+            self.logger.info("Quitting")
+            sys.exit(0)
+
+    def read_local_file(self, path):
+        """Open file in read mode on local filesystem."""
+        return open(path, 'rb')
+
+    # TODO: Define chunk size
+    def write_local_file(self, outputfile, path):
+        """Write file to the desired path."""
+        outputfile.seek(0)
+        with open(path, 'wb') as fd:
+            copyfileobj(outputfile, fd)

--- a/dbbackup/management/commands/dbbackup.py
+++ b/dbbackup/management/commands/dbbackup.py
@@ -80,7 +80,7 @@ class Command(BaseDbBackupCommand):
             outputfile = encrypted_file
         filename = self.filename if self.filename else filename
         if not self.quiet:
-            self.logger.info("Backup tempfile created: %s", utils.handle_size(outputfile))
+            self.logger.info("Backup size: %s", utils.handle_size(outputfile))
         # Store backup
         if self.path is None:
             self.logger.info("Writing file to %s: %s, filename: %s",

--- a/dbbackup/management/commands/dbbackup.py
+++ b/dbbackup/management/commands/dbbackup.py
@@ -15,9 +15,10 @@ from ... import utils, settings as dbbackup_settings
 
 
 class Command(BaseDbBackupCommand):
-    help = """
-    Backup a database, encrypt and/or compress and write to storage.
-    """
+    help = """Backup a database, encrypt and/or compress and write to
+    storage."""
+    content_type = 'db'
+
     option_list = BaseDbBackupCommand.option_list + (
         make_option("-c", "--clean", dest='clean', action="store_true",
                     default=False, help="Clean up old backup files"),
@@ -41,7 +42,6 @@ class Command(BaseDbBackupCommand):
         self.verbosity = int(options.get('verbosity'))
         self.quiet = options.get('quiet')
         self.clean = options.get('clean')
-        self.clean_keep = dbbackup_settings.CLEANUP_KEEP
         self.database = options.get('database')
         self.servername = options.get('servername')
         self.compress = options.get('compress')
@@ -56,10 +56,7 @@ class Command(BaseDbBackupCommand):
             try:
                 self._save_new_backup(database)
                 if self.clean:
-                    self.storage.clean_old_backups(self.encrypt,
-                                                   self.compress,
-                                                   content_type='db',
-                                                   database=self.database)
+                    self._cleanup_old_backups()
             except StorageError as err:
                 raise CommandError(err)
 
@@ -82,10 +79,6 @@ class Command(BaseDbBackupCommand):
             self.logger.info("Backup size: %s", utils.handle_size(outputfile))
         # Store backup
         if self.path is None:
-            self.logger.info("Writing file to %s: %s, filename: %s",
-                             self.storage.name, self.storage.backup_dir,
-                             filename)
-            self.storage.write_file(outputfile, filename)
+            self.write_to_storage(outputfile, filename)
         else:
-            self.logger.info("Writing file to %s", self.path)
             self.write_local_file(outputfile, self.path)

--- a/dbbackup/management/commands/dbbackup.py
+++ b/dbbackup/management/commands/dbbackup.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
 from optparse import make_option
-from shutil import copyfileobj
 
 from django.core.management.base import CommandError
 
@@ -90,10 +89,3 @@ class Command(BaseDbBackupCommand):
         else:
             self.logger.info("Writing file to %s", self.path)
             self.write_local_file(outputfile, self.path)
-
-    # TODO: Define chunk size
-    def write_local_file(self, outputfile, path):
-        """Write file to the desired path."""
-        outputfile.seek(0)
-        with open(path, 'wb') as fd:
-            copyfileobj(outputfile, fd)

--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -4,22 +4,16 @@ Restore database.
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
-import os
-import sys
-import warnings
 from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import CommandError
-from django.utils import six
 from django.db import connection
 
 from ._base import BaseDbBackupCommand
 from ... import utils
 from ...db.base import get_connector
 from ...storage.base import BaseStorage, StorageError
-
-input = raw_input if six.PY2 else input  # @ReservedAssignment
 
 
 class Command(BaseDbBackupCommand):
@@ -31,7 +25,6 @@ class Command(BaseDbBackupCommand):
         make_option("-i", "--input-filename", help="Specify filename to backup from"),
         make_option("-I", "--input-path", help="Specify path on local filesystem to backup from"),
         make_option("-s", "--servername", help="Use a different servername backup"),
-        make_option("-l", "--list", action='store_true', default=False, help="List backups in the backup directory"),
 
         make_option("-c", "--decrypt", help="Decrypt data before restoring", default=False, action='store_true'),
         make_option("-p", "--passphrase", help="Passphrase for decrypt file", default=None),
@@ -54,8 +47,6 @@ class Command(BaseDbBackupCommand):
             self.interactive = options.get('interactive')
             self.database = self._get_database(options)
             self.storage = BaseStorage.storage_factory()
-            if options.get('list'):
-                return self._list_backups()
             self._restore_backup()
         except StorageError as err:
             raise CommandError(err)
@@ -71,9 +62,7 @@ class Command(BaseDbBackupCommand):
             database_key = list(settings.DATABASES.keys())[0]
         return settings.DATABASES[database_key]
 
-    def _restore_backup(self):
-        """Restore the specified database."""
-        self.logger.info("Restoring backup for database: %s", self.database['NAME'])
+    def _get_backup_file(self):
         if self.path:
             input_filename = self.path
             input_file = self.read_local_file(self.path)
@@ -85,12 +74,20 @@ class Command(BaseDbBackupCommand):
                 self.logger.info("Finding latest backup")
                 try:
                     input_filename = self.storage.get_latest_backup(encrypted=self.decrypt,
-                                                                    compressed=self.uncompress)
+                                                                    compressed=self.uncompress,
+                                                                    content_type='db')
                 except StorageError as err:
                     raise CommandError(err.args[0])
             input_file = self.storage.read_file(input_filename)
+        return input_filename, input_file
 
+    def _restore_backup(self):
+        """Restore the specified database."""
+        self.logger.info("Restoring backup for database: %s", self.database['NAME'])
+
+        input_filename, input_file = self._get_backup_file()
         self.logger.info("Restoring: %s" % input_filename)
+
         if self.decrypt:
             unencrypted_file, input_filename = utils.unencrypt_file(input_file, input_filename,
                                                                     self.passphrase)
@@ -100,26 +97,10 @@ class Command(BaseDbBackupCommand):
             uncompressed_file, input_filename = utils.uncompress_file(input_file, input_filename)
             input_file.close()
             input_file = uncompressed_file
+
         self.logger.info("Restore tempfile created: %s", utils.handle_size(input_file))
         if self.interactive:
-            answer = input("Are you sure you want to continue? [Y/n]")
-            if answer.lower().startswith('n'):
-                self.logger.info("Quitting")
-                sys.exit(0)
+            self._ask_confirmation()
+
         input_file.seek(0)
         self.connector.restore_dump(input_file)
-
-    # TODO: Remove this
-    def _list_backups(self):
-        """List backups in the backup directory."""
-        msg = "'dbbrestore --list' is deprecated, use 'listbackup'."
-        warnings.warn(msg, DeprecationWarning)
-        self.logger.info("Listing backups on %s in /%s:", self.storage.name, self.storage.backup_dir)
-        for filepath in self.storage.list_directory():
-            self.logger.info("  %s", os.path.basename(filepath))
-            # TODO: Implement filename_details method
-            # print(utils.filename_details(filepath))
-
-    def read_local_file(self, path):
-        """Open file on local filesystem."""
-        return open(path, 'rb')

--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -13,31 +13,34 @@ from django.core.files.storage import get_storage_class
 from ._base import BaseDbBackupCommand
 from ... import utils
 from ...storage.base import BaseStorage, StorageError
-from ... import settings
 
 
 class Command(BaseDbBackupCommand):
-    help = """
-    Backup media files, gather all in a tarball and encrypt or compress.
-    """
-
+    help = """Backup media files, gather all in a tarball and encrypt or
+    compress."""
     content_type = "media"
 
     option_list = BaseDbBackupCommand.option_list + (
         make_option("-c", "--clean", help="Clean up old backup files", action="store_true",
                     default=False),
         make_option("-s", "--servername", help="Specify server name to include in backup filename"),
-        make_option("-e", "--encrypt", help="Encrypt the backup files", action="store_true",
-                    default=False),
         make_option("-z", "--compress", help="Do not compress the archive", action="store_true",
                     default=False),
+        make_option("-e", "--encrypt", help="Encrypt the backup files", action="store_true",
+                    default=False),
+        make_option("-o", "--output-filename", default=None,
+                    help="Specify filename on storage"),
+        make_option("-O", "--output-path", default=None,
+                    help="Specify where to store on local filesystem",)
     )
 
     @utils.email_uncaught_exception
     def handle(self, *args, **options):
         self.encrypt = options.get('encrypt', False)
         self.compress = options.get('compress', False)
-        self.servername = options.get('servername') or settings.HOSTNAME
+        self.servername = options.get('servername')
+        self.filename = options.get('output_filename')
+        self.path = options.get('output_path')
         try:
             self.media_storage = get_storage_class()()
             self.storage = BaseStorage.storage_factory()
@@ -48,28 +51,8 @@ class Command(BaseDbBackupCommand):
         except StorageError as err:
             raise CommandError(err)
 
-    def backup_mediafiles(self):
-        """
-        Create backup file and write it to storage.
-        """
-        # Create file name
-        extension = "tar%s" % ('.gz' if self.compress else '')
-        filename = utils.filename_generate(extension,
-                                           servername=self.servername,
-                                           content_type=self.content_type)
-
-        outputfile = self._create_tar(filename)
-
-        if self.encrypt:
-            encrypted_file = utils.encrypt_file(outputfile, filename)
-            outputfile, filename = encrypted_file
-
-        self.logger.debug("Backup size: %s", utils.handle_size(outputfile))
-        self.logger.info("Writing file to %s" % filename)
-        self.storage.write_file(outputfile, filename)
-
     def _explore_storage(self):
-        """Generator of a all files contained in media storage."""
+        """Generator of all files contained in media storage."""
         path = ''
         dirs = [path]
         while dirs:
@@ -93,12 +76,24 @@ class Command(BaseDbBackupCommand):
         tar_file.close()
         return fileobj
 
-    def _cleanup_old_backups(self):
+    def backup_mediafiles(self):
         """
-        Cleanup old backups, keeping the number of backups specified by
-        DBBACKUP_CLEANUP_KEEP and any backups that occur on first of the month.
+        Create backup file and write it to storage.
         """
-        self.logger.info("Cleaning Old Backups for media files")
-        file_list = self.storage.clean_old_backups(encrypted=self.encrypt,
-                                                   compressed=self.compress,
-                                                   keep_number=settings.CLEANUP_KEEP_MEDIA)
+        # Create file name
+        extension = "tar%s" % ('.gz' if self.compress else '')
+        filename = utils.filename_generate(extension,
+                                           servername=self.servername,
+                                           content_type=self.content_type)
+
+        outputfile = self._create_tar(filename)
+
+        if self.encrypt:
+            encrypted_file = utils.encrypt_file(outputfile, filename)
+            outputfile, filename = encrypted_file
+
+        self.logger.debug("Backup size: %s", utils.handle_size(outputfile))
+        if self.path is None:
+            self.write_to_storage(outputfile, filename)
+        else:
+            self.storage.write_file(outputfile, filename)

--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -29,14 +29,14 @@ class Command(BaseDbBackupCommand):
         make_option("-s", "--servername", help="Specify server name to include in backup filename"),
         make_option("-e", "--encrypt", help="Encrypt the backup files", action="store_true",
                     default=False),
-        make_option("-x", "--no-compress", help="Do not compress the archive", action="store_true",
+        make_option("-z", "--compress", help="Do not compress the archive", action="store_true",
                     default=False),
     )
 
     @utils.email_uncaught_exception
     def handle(self, *args, **options):
-        self.encrypt = options.get('encrypt')
-        self.compress = not options.get('no_compress')
+        self.encrypt = options.get('encrypt', False)
+        self.compress = options.get('compress', False)
         self.servername = options.get('servername') or settings.HOSTNAME
         try:
             self.media_storage = get_storage_class()()

--- a/dbbackup/management/commands/mediarestore.py
+++ b/dbbackup/management/commands/mediarestore.py
@@ -1,0 +1,93 @@
+"""
+Restore media files.
+"""
+import sys
+import tarfile
+from optparse import make_option
+
+from django.core.management.base import CommandError
+from django.utils import six
+from django.conf import settings
+
+from ._base import BaseDbBackupCommand
+from ...storage.base import BaseStorage, StorageError
+from ...storage.filesystem_storage import Storage as FileSystemStorage
+from ... import utils
+
+input = raw_input if six.PY2 else input  # @ReservedAssignment
+
+
+class Command(BaseDbBackupCommand):
+    option_list = BaseDbBackupCommand.option_list + (
+        make_option("-d", "--database", help="Database to restore"),
+        make_option("-i", "--input-filename", help="Specify filename to backup from"),
+        make_option("-I", "--input-path", help="Specify path on local filesystem to backup from"),
+        make_option("-s", "--servername", help="Use a different servername backup"),
+        make_option("-l", "--list", action='store_true', default=False, help="List backups in the backup directory"),
+
+        make_option("-c", "--decrypt", help="Decrypt data before restoring", default=False, action='store_true'),
+        make_option("-p", "--passphrase", help="Passphrase for decrypt file", default=None),
+        make_option("-z", "--uncompress", help="Uncompress gzip data before restoring", action='store_true'),
+    )
+
+    def handle(self, *args, **options):
+        """Django command handler."""
+        self.verbosity = int(options.get('verbosity'))
+        self.quiet = options.get('quiet')
+        self.filename = options.get('input_filename')
+        self.path = options.get('input_path')
+        self.servername = options.get('servername')
+        self.decrypt = options.get('decrypt')
+        self.uncompress = options.get('uncompress')
+        self.passphrase = options.get('passphrase')
+        self.interactive = options.get('interactive')
+        self.storage = BaseStorage.storage_factory()
+        self._restore_backup()
+
+    def _get_backup_file(self):
+        if self.path:
+            input_filename = self.path
+            input_file = self.read_local_file(self.path)
+        else:
+            if self.filename:
+                input_filename = self.filename
+            # Fetch the latest backup if filepath not specified
+            else:
+                self.logger.info("Finding latest backup")
+                try:
+                    input_filename = self.storage.get_latest_backup(
+                        encrypted=self.decrypt,
+                        compressed=self.uncompress,
+                        content_type='media')
+                except StorageError as err:
+                    raise CommandError(err.args[0])
+            input_file = self.storage.read_file(input_filename)
+        return input_filename, input_file
+
+    def _restore_backup(self):
+        self.logger.info("Restoring backup for media files")
+        input_filename, input_file = self._get_backup_file()
+        self.logger.info("Restoring: %s" % input_filename)
+
+        if self.decrypt:
+            unencrypted_file, input_filename = utils.unencrypt_file(input_file, input_filename,
+                                                                    self.passphrase)
+            input_file.close()
+            input_file = unencrypted_file
+        if self.uncompress:
+            uncompressed_file, input_filename = utils.uncompress_file(input_file, input_filename)
+            input_file.close()
+            input_file = uncompressed_file
+        self.logger.info("Restore tempfile created: %s", utils.handle_size(input_file))
+        if self.interactive:
+            answer = input("Are you sure you want to continue? [Y/n]")
+            if answer.lower().startswith('n'):
+                self.logger.info("Quitting")
+                sys.exit(0)
+        input_file.seek(0)
+
+        tar_file = tarfile.open(fileobj=input_file, mode='r|gz') \
+            if self.uncompress \
+            else tarfile.open(fileobj=input_file, mode='r')
+        # tar_file.extractall(path=settings.MEDIA_ROOT)
+        tar_file.extractall(path='/')

--- a/dbbackup/management/commands/mediarestore.py
+++ b/dbbackup/management/commands/mediarestore.py
@@ -22,7 +22,6 @@ class Command(BaseDbBackupCommand):
         make_option("-d", "--database", help="Database to restore"),
         make_option("-i", "--input-filename", help="Specify filename to backup from"),
         make_option("-I", "--input-path", help="Specify path on local filesystem to backup from"),
-        make_option("-s", "--servername", help="Use a different servername backup"),
         make_option("-l", "--list", action='store_true', default=False, help="List backups in the backup directory"),
 
         make_option("-c", "--decrypt", help="Decrypt data before restoring", default=False, action='store_true'),
@@ -74,10 +73,7 @@ class Command(BaseDbBackupCommand):
                                                                     self.passphrase)
             input_file.close()
             input_file = unencrypted_file
-        if self.uncompress:
-            uncompressed_file, input_filename = utils.uncompress_file(input_file, input_filename)
-            input_file.close()
-            input_file = uncompressed_file
+
         self.logger.info("Restore tempfile created: %s", utils.handle_size(input_file))
         if self.interactive:
             answer = input("Are you sure you want to continue? [Y/n]")

--- a/dbbackup/management/commands/mediarestore.py
+++ b/dbbackup/management/commands/mediarestore.py
@@ -19,10 +19,8 @@ input = raw_input if six.PY2 else input  # @ReservedAssignment
 
 class Command(BaseDbBackupCommand):
     option_list = BaseDbBackupCommand.option_list + (
-        make_option("-d", "--database", help="Database to restore"),
         make_option("-i", "--input-filename", help="Specify filename to backup from"),
         make_option("-I", "--input-path", help="Specify path on local filesystem to backup from"),
-        make_option("-l", "--list", action='store_true', default=False, help="List backups in the backup directory"),
 
         make_option("-c", "--decrypt", help="Decrypt data before restoring", default=False, action='store_true'),
         make_option("-p", "--passphrase", help="Passphrase for decrypt file", default=None),
@@ -80,10 +78,10 @@ class Command(BaseDbBackupCommand):
             if answer.lower().startswith('n'):
                 self.logger.info("Quitting")
                 sys.exit(0)
-        input_file.seek(0)
 
-        tar_file = tarfile.open(fileobj=input_file, mode='r|gz') \
+        input_file.seek(0)
+        tar_file = tarfile.open(fileobj=input_file, mode='r:gz') \
             if self.uncompress \
-            else tarfile.open(fileobj=input_file, mode='r')
+            else tarfile.open(fileobj=input_file, mode='r:')
         # tar_file.extractall(path=settings.MEDIA_ROOT)
         tar_file.extractall(path='/')

--- a/dbbackup/storage/base.py
+++ b/dbbackup/storage/base.py
@@ -107,8 +107,10 @@ class BaseStorage(object):
             files = [f for f in files if ('.gpg' in f) == encrypted]
         if compressed is not None:
             files = [f for f in files if ('.gz' in f) == compressed]
-        if content_type is not None:
-            files = [f for f in files if '%s' % content_type in f]
+        if content_type == 'media':
+            files = [f for f in files if '.tar' in f]
+        elif content_type == 'db':
+            files = [f for f in files if '.tar' not in f]
         if database is not None:
             files = [f for f in files if '%s' % database in f]
         return files

--- a/dbbackup/storage/base.py
+++ b/dbbackup/storage/base.py
@@ -200,7 +200,7 @@ class BaseStorage(object):
         """
         if keep_number is None:
             keep_number = settings.CLEANUP_KEEP if content_type == 'db' \
-                else settings.MEDIA_FILENAME_TEMPLATE
+                else settings.CLEANUP_KEEP_MEDIA
         files = self.list_backups(encrypted=encrypted, compressed=compressed,
                                   content_type=content_type, database=database)
         files = sorted(files, key=utils.filename_to_date, reverse=True)

--- a/dbbackup/tests/commands/test_base.py
+++ b/dbbackup/tests/commands/test_base.py
@@ -6,6 +6,7 @@ from mock import patch
 from django.test import TestCase
 from django.utils import six
 from dbbackup.management.commands._base import BaseDbBackupCommand
+from dbbackup.tests.utils import (FakeStorage, DEV_NULL, HANDLED_FILES)
 
 
 class BaseDbBackupCommandSetLoggerLevelTest(TestCase):
@@ -26,6 +27,22 @@ class BaseDbBackupCommandSetLoggerLevelTest(TestCase):
         self.command.quiet = True
         self.command._set_logger_level()
         self.assertGreater(self.command.logger.level, 50)
+
+
+class BaseDbBackupCommandMethodsTest(TestCase):
+    def setUp(self):
+        HANDLED_FILES.clean()
+        self.command = BaseDbBackupCommand()
+        self.command.storage = FakeStorage()
+
+    def test_read_from_storage(self):
+        HANDLED_FILES['written_files'].append(['foo', six.BytesIO(b'bar')])
+        file_ = self.command.read_from_storage('foo')
+        self.assertEqual(file_.read(), b'bar')
+
+    def test_write_to_storage(self):
+        self.command.write_to_storage(six.BytesIO(b'foo'), 'bar')
+        self.assertEqual(HANDLED_FILES['written_files'][0][0], 'bar')
 
     def test_read_local_file(self):
         # setUp
@@ -63,3 +80,37 @@ class BaseDbBackupCommandSetLoggerLevelTest(TestCase):
         with patch('dbbackup.management.commands._base.input', return_value='No'):
             with self.assertRaises(SystemExit):
                 self.command._ask_confirmation()
+
+
+class BaseDbBackupCommandCleanupOldBackupsTest(TestCase):
+    def setUp(self):
+        HANDLED_FILES.clean()
+        self.command = BaseDbBackupCommand()
+        self.command.stdout = DEV_NULL
+        self.command.encrypt = False
+        self.command.compress = False
+        self.command.servername = 'foo-server'
+        self.command.storage = FakeStorage()
+        HANDLED_FILES['written_files'] = [(f, None) for f in [
+            '2015-02-06-042810.tar',
+            '2015-02-07-042810.tar',
+            '2015-02-08-042810.tar',
+            'foodb-2015-02-06-042810.dump',
+            'foodb-2015-02-07-042810.dump',
+            'foodb-2015-02-08-042810.dump',
+        ]]
+
+    @patch('dbbackup.settings.CLEANUP_KEEP', 1)
+    def test_clean_db(self):
+        self.command.content_type = 'db'
+        self.command.database = 'foodb'
+        self.command._cleanup_old_backups()
+        self.assertEqual(2, len(HANDLED_FILES['deleted_files']))
+        self.assertNotIn('foodb-2015-02-08-042810.dump', HANDLED_FILES['deleted_files'])
+
+    @patch('dbbackup.settings.CLEANUP_KEEP_MEDIA', 1)
+    def test_clean_media(self):
+        self.command.content_type = 'media'
+        self.command._cleanup_old_backups()
+        self.assertEqual(2, len(HANDLED_FILES['deleted_files']))
+        self.assertNotIn('2015-02-08-042810.tar', HANDLED_FILES['deleted_files'])

--- a/dbbackup/tests/commands/test_base.py
+++ b/dbbackup/tests/commands/test_base.py
@@ -1,4 +1,10 @@
+"""
+Tests for base command class.
+"""
+import os
+from mock import patch
 from django.test import TestCase
+from django.utils import six
 from dbbackup.management.commands._base import BaseDbBackupCommand
 
 
@@ -20,3 +26,40 @@ class BaseDbBackupCommandSetLoggerLevelTest(TestCase):
         self.command.quiet = True
         self.command._set_logger_level()
         self.assertGreater(self.command.logger.level, 50)
+
+    def test_read_local_file(self):
+        # setUp
+        self.command.path = '/tmp/foo.bak'
+        open(self.command.path, 'w').close()
+        # Test
+        output_file = self.command.read_local_file(self.command.path)
+        # tearDown
+        os.remove(self.command.path)
+
+    def test_write_local_file(self):
+        fd, path = six.BytesIO(b"foo"), '/tmp/foo.bak'
+        self.command.write_local_file(fd, path)
+        self.assertTrue(os.path.exists(path))
+        # tearDown
+        os.remove(path)
+
+    def test_ask_confirmation(self):
+        # Yes
+        with patch('dbbackup.management.commands._base.input', return_value='y'):
+            self.command._ask_confirmation()
+        with patch('dbbackup.management.commands._base.input', return_value='Y'):
+            self.command._ask_confirmation()
+        with patch('dbbackup.management.commands._base.input', return_value=''):
+            self.command._ask_confirmation()
+        with patch('dbbackup.management.commands._base.input', return_value='foo'):
+            self.command._ask_confirmation()
+        # No
+        with patch('dbbackup.management.commands._base.input', return_value='n'):
+            with self.assertRaises(SystemExit):
+                self.command._ask_confirmation()
+        with patch('dbbackup.management.commands._base.input', return_value='N'):
+            with self.assertRaises(SystemExit):
+                self.command._ask_confirmation()
+        with patch('dbbackup.management.commands._base.input', return_value='No'):
+            with self.assertRaises(SystemExit):
+                self.command._ask_confirmation()

--- a/dbbackup/tests/commands/test_dbbackup.py
+++ b/dbbackup/tests/commands/test_dbbackup.py
@@ -5,12 +5,11 @@ import os
 from mock import patch
 
 from django.test import TestCase
-from django.utils import six
 
 from dbbackup.management.commands.dbbackup import Command as DbbackupCommand
 from dbbackup.db.base import get_connector
 from dbbackup.tests.utils import (FakeStorage, TEST_DATABASE,
-                                  add_public_gpg, clean_gpg_keys, DEV_NULL, TEST_MONGODB)
+                                  add_public_gpg, clean_gpg_keys, DEV_NULL)
 
 
 @patch('dbbackup.settings.GPG_RECIPIENT', 'test@test')
@@ -73,21 +72,3 @@ class DbbackupCommandSaveNewMongoBackupTest(TestCase):
     def test_func(self, mock_run_commands, mock_handle_size):
         self.command._save_new_backup(TEST_DATABASE)
         self.assertTrue(mock_run_commands.called)
-
-
-class DbbackupWriteLocallyTest(TestCase):
-    def setUp(self):
-        self.command = DbbackupCommand()
-        self.command.database = TEST_DATABASE['NAME']
-        self.command.storage = FakeStorage()
-        self.command.stdout = DEV_NULL
-        self.command.filename = None
-        self.command.path = None
-        self.command.connector = get_connector('default')
-
-    def test_write(self):
-        fd, path = six.BytesIO(b"foo"), '/tmp/foo.bak'
-        self.command.write_local_file(fd, path)
-        self.assertTrue(os.path.exists(path))
-        # tearDown
-        os.remove(path)

--- a/dbbackup/tests/commands/test_dbrestore.py
+++ b/dbbackup/tests/commands/test_dbrestore.py
@@ -42,7 +42,7 @@ class DbrestoreCommandRestoreBackupTest(TestCase):
     def test_no_filename(self, *args):
         # Prepare backup
         HANDLED_FILES['written_files'].append(
-            (utils.filename_generate('foo'), get_dump()))
+            (utils.filename_generate(TEST_DATABASE), get_dump()))
         # Check
         self.command.path = None
         self.command.filename = None

--- a/dbbackup/tests/commands/test_dbrestore.py
+++ b/dbbackup/tests/commands/test_dbrestore.py
@@ -1,7 +1,6 @@
 """
 Tests for dbrestore command.
 """
-import os
 from mock import patch
 from tempfile import mktemp
 from shutil import copyfileobj
@@ -21,8 +20,7 @@ from dbbackup.tests.utils import (FakeStorage, TEST_DATABASE,
 
 
 @patch('django.conf.settings.DATABASES', {'default': TEST_DATABASE})
-@patch('dbbackup.management.commands.dbrestore.input', return_value='y')
-@patch('dbbackup.settings.STORAGE', 'dbbackup.tests.utils.FakeStorage')
+@patch('dbbackup.management.commands._base.input', return_value='y')
 class DbrestoreCommandRestoreBackupTest(TestCase):
     def setUp(self):
         self.command = DbrestoreCommand()
@@ -108,8 +106,7 @@ class DbrestoreCommandGetDatabaseTest(TestCase):
             self.command._get_database({})
 
 
-@patch('dbbackup.management.commands.dbrestore.input', return_value='y')
-@patch('dbbackup.settings.STORAGE', 'dbbackup.tests.utils.FakeStorage')
+@patch('dbbackup.management.commands._base.input', return_value='y')
 @patch('dbbackup.db.mongodb.MongoDumpConnector.restore_dump')
 class DbMongoRestoreCommandRestoreBackupTest(TestCase):
     def setUp(self):
@@ -134,17 +131,3 @@ class DbMongoRestoreCommandRestoreBackupTest(TestCase):
         HANDLED_FILES['written_files'].append((TARED_FILE, open(TARED_FILE, 'rb')))
         self.command._restore_backup()
         self.assertTrue(mock_runcommands.called)
-
-
-class DbbackupReadLocalFileTest(TestCase):
-    def setUp(self):
-        self.command = DbrestoreCommand()
-        self.command.path = '/tmp/foo.bak'
-
-    def test_read(self):
-        # setUp
-        open(self.command.path, 'w').close()
-        # Test
-        output_file = self.command.read_local_file(self.command.path)
-        # tearDown
-        os.remove(self.command.path)

--- a/dbbackup/tests/commands/test_listbackups.py
+++ b/dbbackup/tests/commands/test_listbackups.py
@@ -29,12 +29,12 @@ class ListbackupsCommandArgComputingTest(TestCase):
         HANDLED_FILES['written_files'] = [(f, None) for f in [
             '2015-02-06-042810_foo.db', '2015-02-06-042810_foo.db.gz',
             '2015-02-06-042810_foo.db.gpg', '2015-02-06-042810_foo.db.gz.gpg',
-            '2015-02-06-042810_foo.media', '2015-02-06-042810_foo.media.gz',
-            '2015-02-06-042810_foo.media.gpg', '2015-02-06-042810_foo.media.gz.gpg',
+            '2015-02-06-042810_foo.media.tar', '2015-02-06-042810_foo.media.tar.gz',
+            '2015-02-06-042810_foo.media.tar.gpg', '2015-02-06-042810_foo.media.tar.gz.gpg',
             '2015-02-06-042810_bar.db', '2015-02-06-042810_bar.db.gz',
             '2015-02-06-042810_bar.db.gpg', '2015-02-06-042810_bar.db.gz.gpg',
-            '2015-02-06-042810_bar.media', '2015-02-06-042810_bar.media.gz',
-            '2015-02-06-042810_bar.media.gpg', '2015-02-06-042810_bar.media.gz.gpg',
+            '2015-02-06-042810_bar.media.tar', '2015-02-06-042810_bar.media.tar.gz',
+            '2015-02-06-042810_bar.media.tar.gpg', '2015-02-06-042810_bar.media.tar.tar.gz.gpg',
         ]]
 
     def test_list(self):

--- a/dbbackup/tests/commands/test_mediabackup.py
+++ b/dbbackup/tests/commands/test_mediabackup.py
@@ -1,7 +1,6 @@
 """
 Tests for mediabackup command.
 """
-from mock import patch
 from django.test import TestCase
 from django.core.files.storage import get_storage_class
 from dbbackup.management.commands.mediabackup import Command as DbbackupCommand
@@ -18,6 +17,7 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.stdout = DEV_NULL
         self.command.compress = False
         self.command.encrypt = False
+        self.command.path = None
         self.command.media_storage = get_storage_class()()
 
     def test_func(self):
@@ -48,35 +48,3 @@ class MediabackupBackupMediafilesTest(TestCase):
         outputfile = HANDLED_FILES['written_files'][0][1]
         outputfile.seek(0)
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
-
-
-class MediabackupGetBackupFileListTest(TestCase):
-    def setUp(self):
-        self.skipTest("Doesn't work!")
-        self.command = DbbackupCommand()
-        self.command.servername = 'foo-server'
-        self.command.storage = FakeStorage()
-
-    def test_func(self):
-        self.command.get_backup_file_list()
-
-
-class MediabackupCleanUpOldBackupsTest(TestCase):
-    def setUp(self):
-        HANDLED_FILES.clean()
-        self.command = DbbackupCommand()
-        self.command.stdout = DEV_NULL
-        self.command.encrypt = False
-        self.command.compress = False
-        self.command.servername = 'foo-server'
-        self.command.storage = FakeStorage()
-        HANDLED_FILES['written_files'] = [(f, None) for f in [
-            '2015-02-06-042810.bak',
-            '2015-02-07-042810.bak',
-            '2015-02-08-042810.bak',
-        ]]
-
-    @patch('dbbackup.settings.CLEANUP_KEEP_MEDIA', 1)
-    def test_func(self):
-        self.command._cleanup_old_backups()
-        self.assertEqual(2, len(HANDLED_FILES['deleted_files']))

--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -136,21 +136,21 @@ class MediaBackupCommandTest(TestCase):
         outputfile.seek(0)
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
 
-    def test_no_compress(self):
-        argv = ['', 'mediabackup', '--no-compress']
+    def test_compress(self):
+        argv = ['', 'mediabackup', '--compress']
         execute_from_command_line(argv)
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         filename, outputfile = HANDLED_FILES['written_files'][0]
-        self.assertFalse('.gz' in filename)
+        self.assertTrue('.gz' in filename)
 
     @patch('dbbackup.utils.getpass', return_value=None)
-    def test_no_compress_and_encrypted(self, getpass_mock):
-        argv = ['', 'mediabackup', '--no-compress', '--encrypt']
+    def test_compress_and_encrypted(self, getpass_mock):
+        argv = ['', 'mediabackup', '--compress', '--encrypt']
         execute_from_command_line(argv)
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         filename, outputfile = HANDLED_FILES['written_files'][0]
         self.assertTrue('.gpg' in filename)
-        self.assertFalse('.gz' in filename)
+        self.assertTrue('.gz' in filename)
         # Test file content
         outputfile = HANDLED_FILES['written_files'][0][1]
         outputfile.seek(0)
@@ -184,7 +184,7 @@ class MediaRestoreCommandTest(TestCase):
     def test_restore(self, *args):
         # Create backup
         self._create_file('foo')
-        execute_from_command_line(['', 'mediabackup', '--no-compress'])
+        execute_from_command_line(['', 'mediabackup'])
         self._emtpy_media()
         # Restore
         execute_from_command_line(['', 'mediarestore'])
@@ -194,7 +194,7 @@ class MediaRestoreCommandTest(TestCase):
     def test_encrypted(self, *args):
         # Create backup
         self._create_file('foo')
-        execute_from_command_line(['', 'mediabackup', '--no-compress', '--encrypt'])
+        execute_from_command_line(['', 'mediabackup', '--encrypt'])
         self._emtpy_media()
         # Restore
         execute_from_command_line(['', 'mediarestore', '--decrypt'])
@@ -203,7 +203,7 @@ class MediaRestoreCommandTest(TestCase):
     def test_compressed(self, *args):
         # Create backup
         self._create_file('foo')
-        execute_from_command_line(['', 'mediabackup'])
+        execute_from_command_line(['', 'mediabackup', '--compress'])
         self._emtpy_media()
         # Restore
         execute_from_command_line(['', 'mediarestore', '--uncompress'])
@@ -223,7 +223,7 @@ class MediaRestoreCommandTest(TestCase):
 
     def test_available_but_not_compressed(self, *args):
         # Create backup
-        execute_from_command_line(['', 'mediabackup', '--no-compress'])
+        execute_from_command_line(['', 'mediabackup'])
         # Restore
         with self.assertRaises(SystemExit):
             execute_from_command_line(['', 'mediarestore', '--uncompress'])

--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -58,7 +58,7 @@ class DbBackupCommandTest(TestCase):
 
 @patch('django.conf.settings.DATABASES', {'default': TEST_DATABASE})
 @patch('dbbackup.settings.STORAGE', 'dbbackup.tests.utils')
-@patch('dbbackup.management.commands.dbrestore.input', return_value='y')
+@patch('dbbackup.management.commands._base.input', return_value='y')
 class DbRestoreCommandTest(TestCase):
     def setUp(self):
         HANDLED_FILES.clean()
@@ -144,8 +144,7 @@ class MediaBackupCommandTest(TestCase):
         self.assertFalse('.gz' in filename)
 
     @patch('dbbackup.utils.getpass', return_value=None)
-    @patch('dbbackup.management.commands.dbrestore.input', return_value='y')
-    def test_no_compress_and_encrypted(self, getpass_mock, confirm_mock):
+    def test_no_compress_and_encrypted(self, getpass_mock):
         argv = ['', 'mediabackup', '--no-compress', '--encrypt']
         execute_from_command_line(argv)
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
@@ -158,7 +157,7 @@ class MediaBackupCommandTest(TestCase):
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
 
 
-@patch('dbbackup.management.commands.mediarestore.input', return_value='y')
+@patch('dbbackup.management.commands._base.input', return_value='y')
 class MediaRestoreCommandTest(TestCase):
     def setUp(self):
         HANDLED_FILES.clean()

--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from shutil import rmtree
 from mock import patch
 
 from django.test import TransactionTestCase as TestCase
@@ -157,13 +156,6 @@ class MediaBackupCommandTest(TestCase):
         outputfile = HANDLED_FILES['written_files'][0][1]
         outputfile.seek(0)
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
-
-    # def test_available_but_not_compressed(self, *args):
-    #     # Create backup
-    #     execute_from_command_line(['', 'dbbackup'])
-    #     # Restore
-    #     with self.assertRaises(Exception):
-    #         execute_from_command_line(['', 'dbrestore', '--uncompress'])
 
 
 @patch('dbbackup.management.commands.mediarestore.input', return_value='y')

--- a/dbbackup/tests/settings.py
+++ b/dbbackup/tests/settings.py
@@ -16,7 +16,7 @@ MIDDLEWARE_CLASSES = ()
 ROOT_URLCONF = 'dbbackup.tests.testapp.urls'
 SECRET_KEY = "it's a secret to everyone"
 SITE_ID = 1
-MEDIA_ROOT = tempfile.mkdtemp()
+MEDIA_ROOT = os.environ.get('MEDIA_ROOT') or tempfile.mkdtemp()
 INSTALLED_APPS = (
     'dbbackup',
     'dbbackup.tests.testapp',

--- a/dbbackup/tests/test_mediabackup.py
+++ b/dbbackup/tests/test_mediabackup.py
@@ -15,57 +15,37 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.servername = 'foo-server'
         self.command.storage = FakeStorage()
         self.command.stdout = DEV_NULL
+        self.command.compress = False
+        self.command.encrypt = False
 
     def test_func(self):
-        self.command.backup_mediafiles(encrypt=False, compress=False)
+        self.command.backup_mediafiles()
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
 
     def test_compress(self):
-        self.command.backup_mediafiles(encrypt=False, compress=True)
+        self.command.compress = True
+        self.command.backup_mediafiles()
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         self.assertTrue(HANDLED_FILES['written_files'][0][0].endswith('.gz'))
 
     def test_encrypt(self):
+        self.command.encrypt = True
         add_public_gpg()
-        self.command.backup_mediafiles(encrypt=True, compress=False)
+        self.command.backup_mediafiles()
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         outputfile = HANDLED_FILES['written_files'][0][1]
         outputfile.seek(0)
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
 
     def test_compress_and_encrypt(self):
+        self.command.compress = True
+        self.command.encrypt = True
         add_public_gpg()
-        self.command.backup_mediafiles(encrypt=True, compress=True)
+        self.command.backup_mediafiles()
         self.assertEqual(1, len(HANDLED_FILES['written_files']))
         outputfile = HANDLED_FILES['written_files'][0][1]
         outputfile.seek(0)
         self.assertTrue(outputfile.read().startswith(b'-----BEGIN PGP MESSAGE-----'))
-
-
-class MediabackupGetBackupBasenameTest(TestCase):
-    def setUp(self):
-        self.command = DbbackupCommand()
-        self.command.servername = 'foo-server'
-        self.command.storage = FakeStorage()
-
-    def test_func(self):
-        output = self.command.get_backup_basename()
-        self.assertTrue(output.endswith('.tar'))
-
-    def test_compress(self):
-        options = {'compress': True}
-        output = self.command.get_backup_basename(**options)
-        self.assertTrue(output.endswith('.tar.gz'))
-
-    def test_encrypt(self):
-        options = {'compress': True}
-        output = self.command.get_backup_basename(**options)
-        self.assertTrue(output.endswith('.tar.gz'))
-
-    def test_compress_and_encrypt(self):
-        options = {'compress': True}
-        output = self.command.get_backup_basename(**options)
-        self.assertTrue(output.endswith('.tar.gz'))
 
 
 class MediabackupGetBackupFileListTest(TestCase):

--- a/dbbackup/tests/test_mediabackup.py
+++ b/dbbackup/tests/test_mediabackup.py
@@ -3,6 +3,7 @@ Tests for mediabackup command.
 """
 from mock import patch
 from django.test import TestCase
+from django.core.files.storage import get_storage_class
 from dbbackup.management.commands.mediabackup import Command as DbbackupCommand
 from dbbackup.tests.utils import (FakeStorage, DEV_NULL, HANDLED_FILES,
                                   add_public_gpg)
@@ -17,6 +18,7 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.stdout = DEV_NULL
         self.command.compress = False
         self.command.encrypt = False
+        self.command.media_storage = get_storage_class()()
 
     def test_func(self):
         self.command.backup_mediafiles()

--- a/dbbackup/tests/test_storages/test_base.py
+++ b/dbbackup/tests/test_storages/test_base.py
@@ -42,7 +42,7 @@ class StorageListBackupsTest(TestCase):
         ]
         HANDLED_FILES['written_files'] += [
             (utils.filename_generate(ext, 'foo', None, 'media'), None) for ext in
-            ('media', 'media.gz', 'media.gpg', 'media.gz.gpg')
+            ('media.tar', 'media.tar.gz', 'media.tar.gpg', 'media.tar.gz.gpg')
         ]
         HANDLED_FILES['written_files'] += [
             ('file_without_date', None)

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import pytz
+import tempfile
 from mock import patch
 from datetime import datetime
 
@@ -62,7 +63,7 @@ class Email_Uncaught_ExceptionTest(TestCase):
 
 class Encrypt_FileTest(TestCase):
     def setUp(self):
-        self.path = '/tmp/foo'
+        self.path = tempfile.mktemp()
         with open(self.path, 'a') as fd:
             fd.write('foo')
         add_public_gpg()
@@ -97,7 +98,7 @@ class Unencrypt_FileTest(TestCase):
 
 class Compress_FileTest(TestCase):
     def setUp(self):
-        self.path = '/tmp/foo'
+        self.path = tempfile.mktemp()
         with open(self.path, 'a+b') as fd:
             fd.write(b'foo')
 
@@ -120,7 +121,7 @@ class Uncompress_FileTest(TestCase):
 
 class Create_Spooled_Temporary_FileTest(TestCase):
     def setUp(self):
-        self.path = '/tmp/foo'
+        self.path = tempfile.mktemp()
         with open(self.path, 'a') as fd:
             fd.write('foo')
 

--- a/dbbackup/tests/utils.py
+++ b/dbbackup/tests/utils.py
@@ -103,5 +103,6 @@ def get_dump(database=TEST_DATABASE):
     return get_connector().create_dump()
 
 
-def get_dump_name(database=TEST_DATABASE):
+def get_dump_name(database=None):
+    database = database or TEST_DATABASE
     return get_connector().generate_filename()

--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -249,28 +249,27 @@ def uncompress_file(inputfile, filename):
     return outputfile, new_basename
 
 
-def create_spooled_temporary_file(filepath):
+def create_spooled_temporary_file(filepath=None, fileobj=None):
     """
-    Create a spooled temporary file.
+    Create a spooled temporary file. if ``filepath`` or ``fileobj`` is
+    defined its content will be copied into temporary file.
 
     :param filepath: Path of input file
     :type filepath: str
 
-    :returns: file of the spooled temporary file
+    :param fileobj: Input file object
+    :type fileobj: file
+
+    :returns: Spooled temporary file
     :rtype: :class:`tempfile.SpooledTemporaryFile`
     """
     spooled_file = tempfile.SpooledTemporaryFile(
         max_size=settings.TMP_FILE_MAX_SIZE,
         dir=settings.TMP_DIR)
-    tmpfile = open(filepath, 'r+b')
-    try:
-        while True:
-            data = tmpfile.read(1024 * 1000)
-            if not data:
-                break
-            spooled_file.write(data)
-    finally:
-        tmpfile.close()
+    if filepath:
+        fileobj = open(filepath, 'r+b')
+    if fileobj is not None:
+        copyfileobj(fileobj, spooled_file, settings.TMP_FILE_READ_SIZE)
     return spooled_file
 
 

--- a/functional.sh
+++ b/functional.sh
@@ -24,9 +24,9 @@ test_db_results () {
 }
 
 make_media_test () {
-    touch ${MEDIA_ROOT}foo
+    echo foo > ${MEDIA_ROOT}foo
     mkdir -p ${MEDIA_ROOT}bar
-    touch ${MEDIA_ROOT}bar/ham
+    echo ham > ${MEDIA_ROOT}bar/ham
 
     $PYTHON runtests.py mediabackup --no-compress
 

--- a/functional.sh
+++ b/functional.sh
@@ -28,7 +28,7 @@ make_media_test () {
     mkdir -p ${MEDIA_ROOT}bar
     echo ham > ${MEDIA_ROOT}bar/ham
 
-    $PYTHON runtests.py mediabackup --no-compress
+    $PYTHON runtests.py mediabackup
 
     rm -rf ${MEDIA_ROOT}*
     $PYTHON runtests.py mediarestore --noinput

--- a/functional.sh
+++ b/functional.sh
@@ -28,7 +28,7 @@ make_media_test () {
     mkdir -p ${MEDIA_ROOT}bar
     touch ${MEDIA_ROOT}bar/ham
 
-    $PYTHON runtests.py mediabackup
+    $PYTHON runtests.py mediabackup --no-compress
 
     rm -rf ${MEDIA_ROOT}*
     $PYTHON runtests.py mediarestore --noinput

--- a/functional.sh
+++ b/functional.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-make_test () {
+make_db_test () {
     $PYTHON runtests.py migrate --noinput || exit 1
 
     $PYTHON runtests.py feed
@@ -13,30 +13,59 @@ make_test () {
     count2=$($PYTHON runtests.py count)
 }
 
-test_results () {
+test_db_results () {
     if [[ "$count1" -eq "$count2" ]] ; then
-        echo 'Success!'
-        success=0
+        echo 'DB test succeed!'
+        db_success=0
     else
-        echo 'Failed!'
-        success=1
+        echo 'DB test Failed!'
+        db_success=1
     fi
 }
+
+make_media_test () {
+    touch ${MEDIA_ROOT}foo
+    mkdir -p ${MEDIA_ROOT}bar
+    touch ${MEDIA_ROOT}bar/ham
+
+    $PYTHON runtests.py mediabackup
+
+    rm -rf ${MEDIA_ROOT}*
+    $PYTHON runtests.py mediarestore --noinput
+}
+
+test_media_results () {
+    media_success=0
+    [[ -f ${MEDIA_ROOT}foo ]] || media_success=1
+    [[ -d ${MEDIA_ROOT}bar ]] || media_success=1
+    [[ -f ${MEDIA_ROOT}bar/ham ]] || media_success=1
+    [[ "$media_success" -eq 0 ]] && echo "Media test succeed!" || echo "Media test failed!"
+}
+
 
 main () {
     if [[ -z "$DATABASE_URL" ]]; then
         DATABASE_FILE="$(mktemp)"
         export DATABASE_URL="sqlite:///$DATABASE_FILE"
     fi
-    export STORAGE="dbbackup.storage.filesystem_storage"
-    export STORAGE_OPTIONS="location=/tmp/"
     export PYTHON=${PYTHON:-python}
+    export STORAGE="dbbackup.storage.filesystem_storage"
+    export STORAGE_LOCATION="/tmp/backups/"
+    export STORAGE_OPTIONS="location=${STORAGE_LOCATION}"
+    export MEDIA_ROOT="/tmp/media/"
 
-    make_test 
-    test_results
+    make_db_test 
+    test_db_results
+
+    mkdir -p $STORAGE_LOCATION
+    mkdir -p $MEDIA_ROOT
+    make_media_test 
+    test_media_results
 
     [[ -n "$DATABASE_FILE" ]] && rm "$DATABASE_FILE"
-    return $success
+    rm -rf "$MEDIA_ROOT"
+
+    return $((db_success + media_success))
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
I added a mediarestore command and upgrade all related code:
- Tar file was made with absolute path from root, so untaring had to be made to root for get files in right place. It didn't allow to restore files in other address. I changed it for include media files in a directory named 'media'.
- Instead of archive MEDIA_ROOT, the media storage object is used for open files.
- Files are now read 1 by 1 from storage and write into tar file and reverse, it allows to create (in future) exclusions (PR #45)
- I also tried to make this process as efficient as possible, so I change mediabackup for use spooled temporary file