### PR TITLE
Added tests for upgrade from 2.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,18 @@ matrix:
         - DATABASE_URL=sqlite:////tmp/db.sqlite tox -e functional
         - DATABASE_URL=mysql://travis:@localhost/test tox -e functional
         - DATABASE_URL=postgres://postgres:@localhost/test tox -e functional
+    - python: "3.4"
+      env: TOX_ENV=upgrade
+      install:
+        - pip install tox
+        - export PYTHON='coverage run -a'
+      before_install: 
+        - mysql -e 'CREATE DATABASE test;'
+        - psql -c 'CREATE DATABASE test;' -U postgres
+      script:
+        - DATABASE_URL=sqlite:////tmp/db.sqlite tox -e upgrade
+        - DATABASE_URL=mysql://travis:@localhost/test tox -e upgrade
+        - DATABASE_URL=postgres://postgres:@localhost/test tox -e upgrade
   exclude:
     - python: "3.5"
       env: DJANGO=1.6

--- a/dbbackup/tests/testapp/urls.py
+++ b/dbbackup/tests/testapp/urls.py
@@ -1,4 +1,11 @@
-from django.conf.urls import include, url
-urlpatterns = (
-    # url(r'^admin/', include(admin.site.urls)),
-)
+try:
+    from django.conf.urls import patterns, include, url
+    urlpatterns = patterns(
+        '',
+        # url(r'^admin/', include(admin.site.urls)),
+    )
+except ImportError:
+    from django.conf.urls import include, url
+    urlpatterns = (
+        # url(r'^admin/', include(admin.site.urls)),
+    )

--- a/test_upgrade.sh
+++ b/test_upgrade.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. functional.sh
+
+
+backup () {
+    $PYTHON runtests.py migrate --noinput || exit 1
+    $PYTHON runtests.py feed
+    $PYTHON runtests.py dbbackup
+    count1=$($PYTHON runtests.py count)
+}
+
+restore () {
+    $PYTHON runtests.py flush --noinput
+    $PYTHON runtests.py dbrestore --noinput
+    count2=$($PYTHON runtests.py count)
+}
+
+main () {
+    if [[ -z "$DATABASE_URL" ]]; then
+        DATABASE_FILE="$(mktemp)"
+        export DATABASE_URL="sqlite:///$DATABASE_FILE"
+    fi
+    export PYTHON=${PYTHON:-python}
+    export STORAGE="${STORAGE:-django.core.files.storage.FileSystemStorage}"
+    export STORAGE_LOCATION="/tmp/backups/"
+    export STORAGE_OPTIONS="${STORAGE_OPTIONS:-location=$STORAGE_LOCATION}"
+
+    pip install 'django-dbbackup<3' -U
+    backup
+
+    pip install . -U
+    restore
+
+    test_db_results
+
+    [[ -n "$DATABASE_FILE" ]] && rm "$DATABASE_FILE"
+
+    return $((db_success))
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main || exit 1
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -42,3 +42,14 @@ deps =
     psycopg2
 basepython = python
 commands = {posargs:bash -x functional.sh}
+
+[testenv:upgrade]
+passenv = *
+whitelist_externals = bash
+deps =
+    -rrequirements-tests.txt
+    Django<1.10
+    mysqlclient
+    psycopg2
+basepython = python
+commands = {posargs:bash -x test_upgrade.sh}


### PR DESCRIPTION
Added a script `test_upgrade.sh`.
In the same spirit of `functional.sh`, it creates a dump from DBBackup 2.5.x and try to restore with
current version.

No need to test `mediarestore`, it didn't exist. 