### PR TITLE
Fix for mediabackup management command

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -84,7 +84,7 @@ complete, you can follow the required setup below. ::
 
 Add the following to your project's settings: ::
 
-    DBBACKUP_STORAGE = 'storages.backends.s3boto.S3BotoStorageFile'
+    DBBACKUP_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
     DBBACKUP_STORAGE_OPTIONS = {
         'access_key': 'my_id',
         'secret_key': 'my_secret',


### PR DESCRIPTION
After upgrade to 3.0.0 `mediabackup` cmd was broken due to implementation of `tarfile.copyfileobj` waiting for `None` or actual size of src file while `TarInfo().size == 0`.

Also, looks like `MEDIA_DBBACKUP_FILENAME_TEMPLATE` is not used anymore. Should I delete it from my settings too?