### PR TITLE
Fixed disabled django loggers

### DIFF
--- a/dbbackup/log.py
+++ b/dbbackup/log.py
@@ -1,5 +1,6 @@
 DEFAULT_LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'handlers': {
         'console': {
             'formatter': 'base',

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -1,8 +1,10 @@
 # DO NOT IMPORT THIS BEFORE django.configure() has been run!
 
+import logging.config
 import tempfile
 import socket
 from django.conf import settings
+import dbbackup.log
 
 DATABASES = getattr(settings, 'DBBACKUP_DATABASES', list(settings.DATABASES.keys()))
 
@@ -37,8 +39,6 @@ STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})
 CONNECTORS = getattr(settings, 'DBBACKUP_CONNECTORS', {})
 
 # Logging
-from logging import config as log_config
-import dbbackup.log
 LOGGING = getattr(settings, 'DBBACKUP_LOGGING', dbbackup.log.DEFAULT_LOGGING)
-LOG_CONFIGURATOR = log_config.DictConfigurator(LOGGING)
+LOG_CONFIGURATOR = logging.config.DictConfigurator(LOGGING)
 LOG_CONFIGURATOR.configure()

--- a/dbbackup/tests/test_log.py
+++ b/dbbackup/tests/test_log.py
@@ -1,0 +1,78 @@
+import logging
+import django
+from django.test import TestCase
+from testfixtures import log_capture
+
+
+class LoggerDefaultTestCase(TestCase):
+    @log_capture()
+    def test_root(self, captures):
+        logger = logging.getLogger()
+        logger.debug('a noise')
+        logger.info('a message')
+        logger.warning('a warning')
+        logger.error('an error')
+        logger.critical('a critical error')
+        captures.check(
+            ('root', 'DEBUG', 'a noise'),
+            ('root', 'INFO', 'a message'),
+            ('root', 'WARNING', 'a warning'),
+            ('root', 'ERROR', 'an error'),
+            ('root', 'CRITICAL', 'a critical error'),
+        )
+
+    @log_capture()
+    def test_django(self, captures):
+        logger = logging.getLogger('django')
+        logger.debug('a noise')
+        logger.info('a message')
+        logger.warning('a warning')
+        logger.error('an error')
+        logger.critical('a critical error')
+        if django.VERSION < (1, 9):
+            captures.check(
+                ('django', 'DEBUG', 'a noise'),
+                ('django', 'INFO', 'a message'),
+                ('django', 'WARNING', 'a warning'),
+                ('django', 'ERROR', 'an error'),
+                ('django', 'CRITICAL', 'a critical error'),
+            )
+        else:
+            captures.check(
+                ('django', 'INFO', 'a message'),
+                ('django', 'WARNING', 'a warning'),
+                ('django', 'ERROR', 'an error'),
+                ('django', 'CRITICAL', 'a critical error'),
+            )
+
+    @log_capture()
+    def test_dbbackup(self, captures):
+        logger = logging.getLogger('dbbackup.storage')
+        logger.debug('a noise')
+        logger.info('a message')
+        logger.warning('a warning')
+        logger.error('an error')
+        logger.critical('a critical error')
+        captures.check(
+            ('dbbackup.storage', 'DEBUG', 'a noise'),
+            ('dbbackup.storage', 'INFO', 'a message'),
+            ('dbbackup.storage', 'WARNING', 'a warning'),
+            ('dbbackup.storage', 'ERROR', 'an error'),
+            ('dbbackup.storage', 'CRITICAL', 'a critical error'),
+        )
+
+    @log_capture()
+    def test_other_module(self, captures):
+        logger = logging.getLogger('os.path')
+        logger.debug('a noise')
+        logger.info('a message')
+        logger.warning('a warning')
+        logger.error('an error')
+        logger.critical('a critical error')
+        captures.check(
+            ('os.path', 'DEBUG', 'a noise'),
+            ('os.path', 'INFO', 'a message'),
+            ('os.path', 'WARNING', 'a warning'),
+            ('os.path', 'ERROR', 'an error'),
+            ('os.path', 'CRITICAL', 'a critical error'),
+        )

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,3 +7,4 @@ python-gnupg
 django-storages-redux
 pytz
 dj-database-url
+testfixtures


### PR DESCRIPTION
@psychok7 @math609
Could you confirm me, that this PR resolve the issue #203 ?
I will release 3.0.2, just after.

PS: For me, it was simply I forgot ``disable_existing_loggers``:

From [Python Logging doc](https://docs.python.org/2/library/logging.config.html#logging.config.fileConfig):

> disable_existing_loggers – If specified as False, loggers which exist when this call is made are left enabled. The default is True because this enables old behaviour in a backward- compatible way. This behaviour is to disable any existing loggers unless they or their ancestors are explicitly named in the logging configuration.