### PR TITLE
Fix recognition of errors for dbrestore with postgresql

### DIFF
--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -45,6 +45,8 @@ class PgDumpConnector(BaseCommandDBConnector):
         if self.settings.get('USER'):
             cmd += ' --user={}'.format(self.settings['USER'])
         cmd += ' --no-password'
+        # without this, psql terminates with an exit value of 0 regardless of errors
+        cmd += ' --set ON_ERROR_STOP=on'
         if self.single_transaction:
             cmd += ' --single-transaction'
         cmd = '{} {} {}'.format(self.restore_prefix, cmd, self.restore_suffix)


### PR DESCRIPTION
psql will always terminate with an exit value of 0 regardless of SQL
errors during restore. Setting ON_ERROR_STOP=on fixes this.

This doesn't change the actual behavior of psql as long as  --single-transaction is enabled (which is the current default). Without ON_ERROR_STOP and without --single-transaction psql would try to execute the rest of the SQL file and exit succesfully regardless of the number of errors.
