### PR TITLE
avoid encoding problems when handling unicode strings from sqlite db

### DIFF
--- a/dbbackup/db/sqlite.py
+++ b/dbbackup/db/sqlite.py
@@ -34,9 +34,9 @@ class SqliteConnector(BaseDBConnector):
                 # Make SQL commands in 1 line
                 sql = sql.replace('\n    ', '')
                 sql = sql.replace('\n)', ')')
-                fileobj.write("{};\n".format(sql).encode('UTF-8'))
+                fileobj.write(u"{};\n".format(sql).encode('UTF-8'))
             else:
-                fileobj.write("{};\n".format(sql))
+                fileobj.write(u"{};\n".format(sql))
             table_name_ident = table_name.replace('"', '""')
             res = cursor.execute('PRAGMA table_info("{0}")'.format(table_name_ident))
             column_names = [str(table_info[1]) for table_info in res.fetchall()]
@@ -46,12 +46,12 @@ class SqliteConnector(BaseDBConnector):
                          for col in column_names))
             query_res = cursor.execute(q)
             for row in query_res:
-                fileobj.write("{};\n".format(row[0]).encode('UTF-8'))
+                fileobj.write(u"{};\n".format(row[0]).encode('UTF-8'))
             schema_res = cursor.execute(DUMP_ETC)
             for name, type, sql in schema_res.fetchall():
                 if sql.startswith("CREATE INDEX"):
                     sql = sql.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS')
-                fileobj.write('{};\n'.format(sql).encode('UTF-8'))
+                fileobj.write(u'{};\n'.format(sql).encode('UTF-8'))
         cursor.close()
 
     def create_dump(self):


### PR DESCRIPTION
using python 2.X the the format strings must be marked as unicode, because sqlite delivers utf-8 strings

```
string = u'groß' 
"{}".format(string)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xdf' in position 3: ordinal not in range(128)
```

```
string = u'groß' 
u"{}".format(string)
u'gro\xdf'
u"{}".format(string).encode('utf-8')
'gro\xc3\x9f'
```
