### PR TITLE
Added possibility to link custom connectors

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -21,6 +21,9 @@ CONNECTOR_MAPPING = {
     'django.contrib.gis.db.backends.spatialite': 'dbbackup.db.sqlite.SqliteConnector',
 }
 
+if settings.CUSTOM_CONNECTOR_MAPPING:
+    CONNECTOR_MAPPING.update(settings.CUSTOM_CONNECTOR_MAPPING)
+
 
 def get_connector(database_name=None):
     """

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -38,6 +38,8 @@ STORAGE_OPTIONS = getattr(settings, 'DBBACKUP_STORAGE_OPTIONS', {})
 
 CONNECTORS = getattr(settings, 'DBBACKUP_CONNECTORS', {})
 
+CUSTOM_CONNECTOR_MAPPING = getattr(settings, 'DBBACKUP_CONNECTOR_MAPPING', {})
+
 # Logging
 LOGGING = getattr(settings, 'DBBACKUP_LOGGING', dbbackup.log.DEFAULT_LOGGING)
 LOG_CONFIGURATOR = logging.config.DictConfigurator(LOGGING)

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -196,3 +196,16 @@ Create your connector is easy, create a children class from
 :class:`dbbackup.db.base.BaseDBConnector` and create ``create_dump`` and
 ``restore_dump``.  If your connector uses a command line tool heritate from
 :class:`dbbackup.db.base.BaseCommandDBConnector`
+
+Connecting a Custom connector
+-----------------------------
+
+Here is an example, on how to easily connect a custom connector that you have created or even that you simply want to reuse: ::
+
+    DBBACKUP_CONNECTOR_MAPPING = {
+        'transaction_hooks.backends.postgis': 'dbbackup.db.postgresql.PgDumpGisConnector',
+    }
+
+Obviously instead of :class:`dbbackup.db.postgresql.PgDumpGisConnector` you can
+use the custom connector you have created yourself and ``transaction_hooks.backends.postgis``
+is simply the database engine name you are using.


### PR DESCRIPTION
@ZuluPro Hi there, i am not sure if you have a better/simpler way of connecting a custom db connector but i was having problems when i tried to use `'ENGINE': 'transaction_hooks.backends.postgis',` where i would get a `KeyError` in `CONNECTOR_MAPPING` so i figured this could be useful and we can simply use it by adding the following to our own settings file: 

```
DBBACKUP_CONNECTOR_MAPPING = {
    'transaction_hooks.backends.postgis': 'dbbackup.db.postgresql.PgDumpGisConnector',
}
```
In this case i wanted the same behaviour but off course the idea would be connecting to any connecter that is not specified in the dict

The [documentation](http://django-dbbackup.readthedocs.io/en/latest/databases.html#custom-connector) mentions creating custom connectors but it does not mention how to easily connect them.