### PR TITLE
Fix username argument for pg_dump

### DIFF
--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -20,7 +20,7 @@ class PgDumpConnector(BaseCommandDBConnector):
         return super(PgDumpConnector, self).run_command(*args, **kwargs)
 
     def _create_dump(self):
-        cmd = '{} {}'.format(self.dump_cmd, self.settings['NAME'])
+        cmd = '{} --dbname={}'.format(self.dump_cmd, self.settings['NAME'])
         if self.settings.get('HOST'):
             cmd += ' --host={}'.format(self.settings['HOST'])
         if self.settings.get('PORT'):

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -26,7 +26,7 @@ class PgDumpConnector(BaseCommandDBConnector):
         if self.settings.get('PORT'):
             cmd += ' --port={}'.format(self.settings['PORT'])
         if self.settings.get('USER'):
-            cmd += ' --user={}'.format(self.settings['USER'])
+            cmd += ' --username={}'.format(self.settings['USER'])
         cmd += ' --no-password'
         for table in self.exclude:
             cmd += ' --exclude-table={}'.format(table)

--- a/dbbackup/tests/test_connectors.py
+++ b/dbbackup/tests/test_connectors.py
@@ -281,11 +281,11 @@ class PgDumpConnectorTest(TestCase):
         # Without
         connector.settings.pop('USER', None)
         connector.create_dump()
-        self.assertNotIn(' --user=', mock_dump_cmd.call_args[0][0])
+        self.assertNotIn(' --username=', mock_dump_cmd.call_args[0][0])
         # With
         connector.settings['USER'] = 'foo'
         connector.create_dump()
-        self.assertIn(' --user=foo', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --username=foo', mock_dump_cmd.call_args[0][0])
 
     def test_create_dump_exclude(self, mock_dump_cmd):
         connector = PgDumpConnector()


### PR DESCRIPTION
Correct parameter according to the pg_dump documentation is `--username`: https://www.postgresql.org/docs/9.6/static/app-pgdump.html

Getting error with `--user`:
pg_dump: too many command-line arguments (first is "--host=127.0.0.1")