### PR TITLE
Make use of the option "output-filename" in mediabackup command

### DIFF
--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -86,10 +86,15 @@ class Command(BaseDbBackupCommand):
         Create backup file and write it to storage.
         """
         # Create file name
-        extension = "tar%s" % ('.gz' if self.compress else '')
-        filename = utils.filename_generate(extension,
-                                           servername=self.servername,
-                                           content_type=self.content_type)
+        # Check for filename option
+        if self.filename:
+            filename = self.filename
+        else:
+            extension = "tar%s" % ('.gz' if self.compress else '')
+            filename = utils.filename_generate(extension,
+                                               servername=self.servername,
+                                               content_type=self.content_type)
+
         tarball = self._create_tar(filename)
         # Apply trans
         if self.encrypt:

--- a/dbbackup/tests/commands/test_mediabackup.py
+++ b/dbbackup/tests/commands/test_mediabackup.py
@@ -20,6 +20,7 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.compress = False
         self.command.encrypt = False
         self.command.path = None
+        self.command.filename = None
         self.command.media_storage = get_storage_class()()
 
     def tearDown(self):


### PR DESCRIPTION
Implements the option output-filename in the mediabackup command.