### PR TITLE
Adds option to keep certain old backups

### DIFF
--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -19,6 +19,7 @@ TMP_FILE_READ_SIZE = getattr(settings, 'DBBACKUP_TMP_FILE_READ_SIZE', 1024*1000)
 # Days to keep
 CLEANUP_KEEP = getattr(settings, 'DBBACKUP_CLEANUP_KEEP', 10)
 CLEANUP_KEEP_MEDIA = getattr(settings, 'DBBACKUP_CLEANUP_KEEP_MEDIA', CLEANUP_KEEP)
+CLEANUP_KEEP_FILTER = getattr(settings, 'DBBACKUP_CLEANUP_KEEP_FILTER', lambda x: False)
 
 MEDIA_PATH = getattr(settings, 'DBBACKUP_MEDIA_PATH', settings.MEDIA_ROOT)
 

--- a/dbbackup/storage.py
+++ b/dbbackup/storage.py
@@ -232,10 +232,13 @@ class Storage(object):
         if keep_number is None:
             keep_number = settings.CLEANUP_KEEP if content_type == 'db' \
                 else settings.CLEANUP_KEEP_MEDIA
+        keep_filter = settings.CLEANUP_KEEP_FILTER
         files = self.list_backups(encrypted=encrypted, compressed=compressed,
                                   content_type=content_type, database=database,
                                   servername=servername)
         files = sorted(files, key=utils.filename_to_date, reverse=True)
         files_to_delete = [fi for i, fi in enumerate(files) if i >= keep_number]
         for filename in files_to_delete:
+            if keep_filter(filename):
+                continue
             self.delete_file(filename)

--- a/dbbackup/tests/test_storage.py
+++ b/dbbackup/tests/test_storage.py
@@ -1,5 +1,5 @@
 from mock import patch
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from dbbackup.storage import get_storage, Storage
 from dbbackup.tests.utils import HANDLED_FILES, FakeStorage
 from dbbackup import utils

--- a/dbbackup/tests/test_storage.py
+++ b/dbbackup/tests/test_storage.py
@@ -1,5 +1,5 @@
 from mock import patch
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from dbbackup.storage import get_storage, Storage
 from dbbackup.tests.utils import HANDLED_FILES, FakeStorage
 from dbbackup import utils
@@ -152,6 +152,11 @@ class StorageGetMostRecentTest(TestCase):
         self.assertEqual(filename, '2015-02-06-042810.bak')
 
 
+def keep_only_even_files(filename):
+    from dbbackup.utils import filename_to_date
+    return filename_to_date(filename).day % 2 == 0
+
+
 class StorageCleanOldBackupsTest(TestCase):
     def setUp(self):
         self.storage = get_storage()
@@ -165,3 +170,8 @@ class StorageCleanOldBackupsTest(TestCase):
     def test_func(self):
         self.storage.clean_old_backups(keep_number=1)
         self.assertEqual(2, len(HANDLED_FILES['deleted_files']))
+
+    @patch('dbbackup.settings.CLEANUP_KEEP_FILTER', keep_only_even_files)
+    def test_keep_filter(self):
+        self.storage.clean_old_backups(keep_number=1)
+        self.assertListEqual(['2015-02-07-042810.bak'], HANDLED_FILES['deleted_files'])

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,6 +36,19 @@ number of old backup files are looked for and removed.
 
 Default: ``10`` (backups)
 
+
+DBBACKUP_CLEANUP_FILTER
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A callable that takes a filename (of an old backup, to be cleaned) and returns
+a boolean indicating whether the backup should be kept (``True``) or deleted
+(``False``).
+
+Default: ``lambda filename: False``
+
+This can be used to keep monthly backups, for example.
+
+
 DBBACKUP_DATE_FORMAT
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 Sphinx==1.3.1
+docutils<0.13.1  # https://github.com/sphinx-doc/sphinx/issues/3212
 sphinx-django-command
 dj-database-url


### PR DESCRIPTION
We have a requirement in our backup policy that we keep backups from the first day of every month (beyond the `DBBACKUP_CLEANUP_KEEP` 'daily' backups).

This new option provides a flexible way to configure such a policy, especially together with `utils.filename_to_date`.