### PR TITLE
Quick fix for proper selection of DB name to restore

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -39,7 +39,6 @@ class Command(BaseDbBackupCommand):
         self.quiet = options.get('quiet')
         self._set_logger_level()
 
-        self.connector = get_connector('default')
         try:
             connection.close()
             self.filename = options.get('input_filename')
@@ -91,4 +90,5 @@ class Command(BaseDbBackupCommand):
             self._ask_confirmation()
 
         input_file.seek(0)
+        self.connector = get_connector(self.database_name)
         self.connector.restore_dump(input_file)


### PR DESCRIPTION
Currently database 'default' is hardcoded