### PR TITLE
FIxes to run dbbackup management command in Postgres for non-latin Windows.

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -141,7 +141,7 @@ class BaseCommandDBConnector(BaseDBConnector):
             if process.poll():
                 stderr.seek(0)
                 raise exceptions.CommandConnectorError(
-                    "Error running: {}\n{}".format(command, stderr.read()))
+                    "Error running: {}\n{}".format(command, stderr.read().decode('utf-8')))
             stdout.seek(0)
             stderr.seek(0)
             return stdout, stderr

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -21,7 +21,7 @@ class PgDumpConnector(BaseCommandDBConnector):
         return super(PgDumpConnector, self).run_command(*args, **kwargs)
 
     def _create_dump(self):
-        cmd = '{} {}'.format(self.dump_cmd, self.settings['NAME'])
+        cmd = '{} '.format(self.dump_cmd)
         if self.settings.get('HOST'):
             cmd += ' --host={}'.format(self.settings['HOST'])
         if self.settings.get('PORT'):
@@ -33,12 +33,13 @@ class PgDumpConnector(BaseCommandDBConnector):
             cmd += ' --exclude-table={}'.format(table)
         if self.drop:
             cmd += ' --clean'
+        cmd += ' {}'.format(self.settings['NAME'])
         cmd = '{} {} {}'.format(self.dump_prefix, cmd, self.dump_suffix)
         stdout, stderr = self.run_command(cmd, env=self.dump_env)
         return stdout
 
     def _restore_dump(self, dump):
-        cmd = '{} {}'.format(self.restore_cmd, self.settings['NAME'])
+        cmd = '{} '.format(self.restore_cmd)
         if self.settings.get('HOST'):
             cmd += ' --host={}'.format(self.settings['HOST'])
         if self.settings.get('PORT'):
@@ -50,6 +51,7 @@ class PgDumpConnector(BaseCommandDBConnector):
         cmd += ' --set ON_ERROR_STOP=on'
         if self.single_transaction:
             cmd += ' --single-transaction'
+        cmd += ' {}'.format(self.settings['NAME'])
         cmd = '{} {} {}'.format(self.restore_prefix, cmd, self.restore_suffix)
         stdout, stderr = self.run_command(cmd, stdin=dump, env=self.restore_env)
         return stdout, stderr


### PR DESCRIPTION
Fix 'pg_dump too many command-line arguments' error in Windows / Postgres 9.4 (command-line arguments must precede database name).

Fix non-Latin bytes error result of pg_dump being displayed / logged as hex bytes instead of easily readable utf-8 string.