### PR TITLE
Using exclude-table-data instead for Postgres

### DIFF
--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -30,7 +30,7 @@ class PgDumpConnector(BaseCommandDBConnector):
             cmd += ' --username={}'.format(self.settings['USER'])
         cmd += ' --no-password'
         for table in self.exclude:
-            cmd += ' --exclude-table={}'.format(table)
+            cmd += ' --exclude-table-data={}'.format(table)
         if self.drop:
             cmd += ' --clean'
         cmd = '{} {} {}'.format(self.dump_prefix, cmd, self.dump_suffix)
@@ -101,7 +101,7 @@ class PgDumpBinaryConnector(PgDumpConnector):
         cmd += ' --no-password'
         cmd += ' --format=custom'
         for table in self.exclude:
-            cmd += ' --exclude-table={}'.format(table)
+            cmd += ' --exclude-table-data={}'.format(table)
         cmd = '{} {} {}'.format(self.dump_prefix, cmd, self.dump_suffix)
         stdout, stderr = self.run_command(cmd, env=self.dump_env)
         return stdout

--- a/dbbackup/tests/test_connectors/test_postgresql.py
+++ b/dbbackup/tests/test_connectors/test_postgresql.py
@@ -59,16 +59,16 @@ class PgDumpConnectorTest(TestCase):
         connector = PgDumpConnector()
         # Without
         connector.create_dump()
-        self.assertNotIn(' --exclude-table=', mock_dump_cmd.call_args[0][0])
+        self.assertNotIn(' --exclude-table-data=', mock_dump_cmd.call_args[0][0])
         # With
         connector.exclude = ('foo',)
         connector.create_dump()
-        self.assertIn(' --exclude-table=foo', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=foo', mock_dump_cmd.call_args[0][0])
         # With serveral
         connector.exclude = ('foo', 'bar')
         connector.create_dump()
-        self.assertIn(' --exclude-table=foo', mock_dump_cmd.call_args[0][0])
-        self.assertIn(' --exclude-table=bar', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=foo', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=bar', mock_dump_cmd.call_args[0][0])
 
     def test_create_dump_drop(self, mock_dump_cmd):
         connector = PgDumpConnector()
@@ -183,16 +183,16 @@ class PgDumpBinaryConnectorTest(TestCase):
         connector = PgDumpBinaryConnector()
         # Without
         connector.create_dump()
-        self.assertNotIn(' --exclude-table=', mock_dump_cmd.call_args[0][0])
+        self.assertNotIn(' --exclude-table-data=', mock_dump_cmd.call_args[0][0])
         # With
         connector.exclude = ('foo',)
         connector.create_dump()
-        self.assertIn(' --exclude-table=foo', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=foo', mock_dump_cmd.call_args[0][0])
         # With serveral
         connector.exclude = ('foo', 'bar')
         connector.create_dump()
-        self.assertIn(' --exclude-table=foo', mock_dump_cmd.call_args[0][0])
-        self.assertIn(' --exclude-table=bar', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=foo', mock_dump_cmd.call_args[0][0])
+        self.assertIn(' --exclude-table-data=bar', mock_dump_cmd.call_args[0][0])
 
     def test_create_dump_drop(self, mock_dump_cmd):
         connector = PgDumpBinaryConnector()


### PR DESCRIPTION
@ZuluPro This PR fixes: https://github.com/django-dbbackup/django-dbbackup/issues/274