### PR TITLE
Updated settings.DBBACKUP_STORAGE

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ In your ``settings.py``, make sure you have the following things:
         'dbbackup',  # django-dbbackup
     )
 
-    DBBACKUP_STORAGE = 'dbbackup.storage.filesystem_storage'
+    DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
     DBBACKUP_STORAGE_OPTIONS = {'location': '/var/backups'}
 
 This configuration uses filesystem storage, but you can use any storage


### PR DESCRIPTION
The previous path: dbbackup.storage.FileSystemStorage gave the following error: AttributeError: module 'dbbackup.storage' has no attribute 'FileSystemStorage'