### PR TITLE
Remove raising exception part when process terminate normally

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -145,8 +145,7 @@ class BaseCommandDBConnector(BaseDBConnector):
             process.wait()
             if process.poll():
                 stderr.seek(0)
-                raise exceptions.CommandConnectorError(
-                    "Error running: {}\n{}".format(command, stderr.read()))
+
             stdout.seek(0)
             stderr.seek(0)
             return stdout, stderr


### PR DESCRIPTION
I think 

```
            raise exceptions.CommandConnectorError(
                    "Error running: {}\n{}".format(command, stderr.read()))
```
part should be erased because `process.poll()` returning 1 means process terminated without any error?