### PR TITLE
Add missing argument to docs for backup_filename function

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,7 +73,7 @@ also be made a function which takes the following keyword arguments:
 
 ::
 
-    def backup_filename(databasename, servername, datetime, extension):
+    def backup_filename(databasename, servername, datetime, extension, content_type):
         pass
 
     DBBACKUP_FILENAME_TEMPLATE = backup_filename


### PR DESCRIPTION
`content_type` is a required keyword argument when defining a custom `backup_filename` function but was not in the configuration docs.