### PR TITLE
fix for issue 301

### DIFF
--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -425,4 +425,4 @@ def filename_generate(extension, database_name='', servername=None, content_type
 
 
 def get_escaped_command_arg(arg):
-    return quote(arg)
+    return arg if os.name == 'nt' else quote(arg)


### PR DESCRIPTION
Fix for issue https://github.com/django-dbbackup/django-dbbackup/issues/301

escaped password failing on windows machine, working fine on Linux/Unix based systems