### PR TITLE
sqlite3: don't throw warnings if table already exists

### DIFF
--- a/dbbackup/db/sqlite.py
+++ b/dbbackup/db/sqlite.py
@@ -32,6 +32,7 @@ class SqliteConnector(BaseDBConnector):
             if table_name.startswith('sqlite_') or table_name in self.exclude:
                 continue
             elif sql.startswith('CREATE TABLE'):
+                sql = sql.replace('CREATE TABLE', 'CREATE TABLE IF NOT EXISTS')
                 # Make SQL commands in 1 line
                 sql = sql.replace('\n    ', '')
                 sql = sql.replace('\n)', ')')


### PR DESCRIPTION
reduces noise by failing sql commands.

further todo for tests: clear first sqlite database before restoring. Otherwise the old data is still in it.