### PR TITLE
"output-filename" in mediabackup command

### DIFF
--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -85,11 +85,15 @@ class Command(BaseDbBackupCommand):
         """
         Create backup file and write it to storage.
         """
-        # Create file name
-        extension = "tar%s" % ('.gz' if self.compress else '')
-        filename = utils.filename_generate(extension,
-                                           servername=self.servername,
-                                           content_type=self.content_type)
+        # Check for filename option
+        if self.filename:
+            filename = self.filename
+        else:
+            extension = "tar%s" % ('.gz' if self.compress else '')
+            filename = utils.filename_generate(extension,
+                                               servername=self.servername,
+                                               content_type=self.content_type)
+        
         tarball = self._create_tar(filename)
         # Apply trans
         if self.encrypt:

--- a/dbbackup/tests/commands/test_mediabackup.py
+++ b/dbbackup/tests/commands/test_mediabackup.py
@@ -21,6 +21,7 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.encrypt = False
         self.command.path = None
         self.command.media_storage = get_storage_class()()
+        self.command.filename = None
 
     def tearDown(self):
         if self.command.path is not None:
@@ -63,3 +64,8 @@ class MediabackupBackupMediafilesTest(TestCase):
         self.command.backup_mediafiles()
         self.assertTrue(os.path.exists(self.command.path))
         self.assertEqual(0, len(HANDLED_FILES['written_files']))
+    
+    def test_output_filename(self):
+        self.command.filename = "my_new_name.tar"
+        self.command.backup_mediafiles()
+        self.assertEqual(HANDLED_FILES['written_files'][0][0], self.command.filename)


### PR DESCRIPTION
Fix mediabackup command to honor output-filename option.
resumes work of PR#236
solves issue #276 
