### PR TITLE
Add machinery for auto-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
   - "pypy3"
   - "nightly"
 
-
 services:
   - mysql
   - postgresql
@@ -89,3 +88,22 @@ matrix:
     - python: "nightly"
     - env: DJANGO=master
     - env: TOX_ENV=functional-mongodb
+
+stages:
+  - test
+  - deploy
+
+jobs:
+  include:
+    - stage: deploy
+      python: 3.8
+      install: skip  # no tests, no dependencies needed
+      script: skip  # we're not running tests
+      deploy:
+        provider: pypi
+        user: ZuluPro  # TODO - is this correct
+        password:
+          secure: "TODO"  # TODO - populate this
+        on:
+          tags: true
+        distributions: sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python
+import os
 from setuptools import setup, find_packages
 import dbbackup
 
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
 def get_requirements():
-    return open('requirements.txt').read().splitlines()
+    with open(os.path.join(ROOT_DIR, 'requirements.txt')) as fh:
+        return fh.read().splitlines()
 
 
 def get_test_requirements():
-    return open('requirements-tests.txt').read().splitlines()
+    with open(os.path.join(ROOT_DIR, 'requirements-tests.txt')) as fh:
+        return fh.read().splitlines()
+
+
+def get_long_description():
+    with open(os.path.join(ROOT_DIR, 'README.rst')) as fh:
+        return fh.read()
+
 
 keywords = [
     'django', 'database', 'media', 'backup',
@@ -19,6 +31,7 @@ setup(
     name='django-dbbackup',
     version=dbbackup.__version__,
     description=dbbackup.__doc__,
+    long_description=get_long_description(),
     author=dbbackup.__author__,
     author_email=dbbackup.__email__,
     install_requires=get_requirements(),


### PR DESCRIPTION
It would be great to get a new release that includes the fixes necessary for use with Django 3.0. This PR adds support for auto-releasing of packages to PyPI. It needs some manual modifications from someone with write access to the project on PyPI, but once done cutting a new release should be as simple as pushing a new tag.

The necessary steps are described [here](https://docs.travis-ci.com/user/deployment/pypi/). In short, you'll need to run the following:

1. Generate an API token from [here](https://pypi.org/manage/account/).

2. Install the travis gem

    ```
    gem install travis --no-rdoc --no-ri
    ```

3. Generate an encrypted, project-specific version of that token.

    ```
    travis encrypt [your-api-token]
    ```

4. Paste the encrypted token into the `jobs.include[0].deploy.password.secure` setting

5. Profit