### PR TITLE
Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/dbbackup/apps.py
+++ b/dbbackup/apps.py
@@ -1,6 +1,6 @@
 """Apps for DBBackup"""
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy
 
 
 class DbbackupConfig(AppConfig):
@@ -9,7 +9,7 @@ class DbbackupConfig(AppConfig):
     """
     name = 'dbbackup'
     label = 'dbbackup'
-    verbose_name = _('Backup and restore')
+    verbose_name = gettext_lazy('Backup and restore')
 
     def ready(self):
         from dbbackup import checks


### PR DESCRIPTION
when running `python3 -Wd manage.py runserver` in my Django 3.0 project, I see:
```
venv/lib/python3.8/site-packages/dbbackup/apps.py:12: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  verbose_name = _('Backup and restore')
/venv/lib/python3.8/site-packages/dbbackup/apps.py:12: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  verbose_name = _('Backup and restore')
```

I'm unsure of any unintended consequences, but `gettext_lazy` has been available since Django 1.8 or earlier