### PR TITLE
Drop django 1.11 and python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -18,7 +17,6 @@ services:
 
 env:
   matrix:
-    - DJANGO=1.11
     - DJANGO=2.2
     - DJANGO=3.0
     - DJANGO=master
@@ -67,19 +65,11 @@ matrix:
       script:
         - DB_ENGINE=djongo DB_NAME=test tox -e $TOX_ENV
   exclude:
-    - python: "nightly"
-      env: DJANGO=1.11
     - python: "pypy"
       env: DJANGO=2.2
     - python: "pypy"
       env: DJANGO=3.0
     - python: "pypy"
-      env: DJANGO=master
-    - python: "2.7"
-      env: DJANGO=2.2
-    - python: "2.7"
-      env: DJANGO=3.0
-    - python: "2.7"
       env: DJANGO=master
     - python: "3.5"
       env: DJANGO=3.0

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -137,10 +137,6 @@ when making a backup with the ``--encrypt`` or ``--decrypt`` option.
 Email configuration
 -------------------
 
-.. note::
-    
-    Django 1.6 won't send the full traceback
-
 DBBACKUP_SEND_EMAIL
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,8 +41,8 @@ Compatibility
 -------------
 
 As we want to ensure a lot of platforms will be able to save data before
-upgrading, Django-DBBackup supports PyPy, Python 2.7, 3.2 to 3.5 and Django
-greater than 1.6.
+upgrading, Django-DBBackup supports PyPy, 3.2 to 3.5 and Django
+greater than 2.2
 
 Other Resources
 ===============

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py{2.7,3.5,3.6,3.7,pypy}-django1.11,py{3.5,3.6,3.7,3.8,nightly}-django2.2,py{3.6,3.7,3.8,nightly}-django{3.0,master},lint,docs,functional
+envlist = py{3.5,3.6,3.7,3.8,nightly}-django2.2,py{3.6,3.7,3.8,nightly}-django{3.0,master},lint,docs,functional
 
 [testenv]
 passenv = *
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 basepython =
-    py2.7: python2.7
     py3.5: python3.5
     py3.6: python3.6
     py3.7: python3.7
@@ -16,7 +15,6 @@ basepython =
     pynightly: python
 deps =
     -rrequirements-tests.txt
-    django1.11: Django>=1.11,<1.12
     django2.2: Django>=2.2,<2.3
     django3.0: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.zip


### PR DESCRIPTION
As support is deprecated for django 1.11 and python 2.7 we drop them from travis and tox. As of this pull request it works but we make no guarantees of it working going forwards. 