### PR TITLE
Add support for exclude tables data in the command interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ filename. ::
                           Specify filename on storage
     -O OUTPUT_PATH, --output-path=OUTPUT_PATH
                           Specify where to store on local filesystem
+    -x EXCLUDE_TABLES, --exclude-tables=EXCLUDE_TABLES
+                          Exclude tables data from backup (-x 'public.table1, public.table2')
 
 dbrestore
 ---------

--- a/dbbackup/management/commands/dbbackup.py
+++ b/dbbackup/management/commands/dbbackup.py
@@ -32,7 +32,9 @@ class Command(BaseDbBackupCommand):
         make_option("-o", "--output-filename", default=None,
                     help="Specify filename on storage"),
         make_option("-O", "--output-path", default=None,
-                    help="Specify where to store on local filesystem")
+                    help="Specify where to store on local filesystem"),
+        make_option("-x", "--exclude-tables", default=None,
+                    help="Exclude tables from backup")
     )
 
     @utils.email_uncaught_exception
@@ -49,6 +51,7 @@ class Command(BaseDbBackupCommand):
 
         self.filename = options.get('output_filename')
         self.path = options.get('output_path')
+        self.exclude_tables = options.get("exclude_tables")
         self.storage = get_storage()
 
         self.database = options.get('database') or ''
@@ -56,6 +59,8 @@ class Command(BaseDbBackupCommand):
 
         for database_key in database_keys:
             self.connector = get_connector(database_key)
+            if self.connector and self.exclude_tables:
+                self.connector.exclude.extend(list(self.exclude_tables.replace(" ", "").split(',')))
             database = self.connector.settings
             try:
                 self._save_new_backup(database)


### PR DESCRIPTION
Type of PR enhancement

Description
Added support for excluding tables data from backingup.

Why should this be added
Sometimes we have some tables in the database that are generated automatically and we don't want to backup the data of these tables if the process take a lot of time, instead we'll generate them again automatically.

Explain value.
We gain time when migrating big databases by excluding unneeded tables data.

Fixes #374 
## Checklist

- [ok] Tests are passing
- [ok] Documentation has been added or amended for this feature / update
