### PR TITLE
auth source added in mongodb. authentication issue fixed with mongodb…

### DIFF
--- a/dbbackup/db/mongodb.py
+++ b/dbbackup/db/mongodb.py
@@ -21,6 +21,8 @@ class MongoDumpConnector(BaseCommandDBConnector):
             cmd += ' --username {}'.format(self.settings['USER'])
         if self.settings.get('PASSWORD'):
             cmd += ' --password {}'.format(utils.get_escaped_command_arg(self.settings['PASSWORD']))
+        if self.settings.get('AUTH_SOURCE'):
+            cmd += ' --authenticationDatabase {}'.format(self.settings['AUTH_SOURCE'])
         for collection in self.exclude:
             cmd += ' --excludeCollection {}'.format(collection)
         cmd += ' --archive'
@@ -37,6 +39,8 @@ class MongoDumpConnector(BaseCommandDBConnector):
             cmd += ' --username {}'.format(self.settings['USER'])
         if self.settings.get('PASSWORD'):
             cmd += ' --password {}'.format(utils.get_escaped_command_arg(self.settings['PASSWORD']))
+        if self.settings.get('AUTH_SOURCE'):
+            cmd += ' --authenticationDatabase {}'.format(self.settings['AUTH_SOURCE'])
         if self.object_check:
             cmd += ' --objcheck'
         if self.drop:

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -1,7 +1,6 @@
 from urllib.parse import quote
 import logging
 
-from dbbackup import utils
 from .base import BaseCommandDBConnector
 from .exceptions import DumpError
 

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -197,6 +197,25 @@ MongoDB
 MongoDB uses by default :class:`dbbackup.db.mongodb.MongoDumpConnector`. it
 uses ``mongodump`` and ``mongorestore`` for its job.
 
+For AuthEnabled MongoDB Connection, you need to add one custom option ``AUTH_SOURCE`` in your ``DBBACKUP_CONNECTORS``. ::
+
+    DBBACKUP_CONNECTORS = {
+        'default': {
+            ...
+            'AUTH_SOURCE': 'admin',
+        }
+    }
+
+Or in ``DATABASES`` one: ::
+
+    DATABASES = {
+        'default': {
+            ...
+            'AUTH_SOURCE': 'admin',
+        }
+    }
+
+
 OBJECT_CHECK
 ~~~~~~~~~~~~
 


### PR DESCRIPTION

# Added authenticationDatabase support for MongoDB

## Description

included --authenticationDatabase argument in the backup and restore command

## Why should this be added

I come across this issue today when I attempted to backup my MongoDB database. authenticationDatabase option should be there with username and password.

## Checklist

- [ ] Tests are passing
- [x] Documentation has been added or amended for this feature / update
