### PR TITLE
Remove deprecation warning RemovedInDjango40Warning

### DIFF
--- a/dbbackup/apps.py
+++ b/dbbackup/apps.py
@@ -2,9 +2,9 @@
 
 from django.apps import AppConfig
 try:
-    from django.utils.translation import gettext_lazy as _
-except:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _ # noqa: F401
+except: # noqa: E722
+    from django.utils.translation import ugettext_lazy as _ # noqa: F401
 
 from dbbackup import log
 
@@ -15,7 +15,7 @@ class DbbackupConfig(AppConfig):
     """
     name = 'dbbackup'
     label = 'dbbackup'
-    verbose_name = gettext_lazy('Backup and restore')
+    verbose_name = _('Backup and restore')
 
     def ready(self):
         log.load()

--- a/dbbackup/apps.py
+++ b/dbbackup/apps.py
@@ -3,7 +3,7 @@
 from django.apps import AppConfig
 try:
     from django.utils.translation import gettext_lazy as _  # noqa: F401
-except:  # noqa: E722
+except ImportError:  # noqa: E722
     from django.utils.translation import ugettext_lazy as _  # noqa: F401
 
 from dbbackup import log

--- a/dbbackup/apps.py
+++ b/dbbackup/apps.py
@@ -1,7 +1,10 @@
 """Apps for DBBackup"""
 
 from django.apps import AppConfig
-from django.utils.translation import gettext_lazy
+try:
+    from django.utils.translation import gettext_lazy as _
+except:
+    from django.utils.translation import ugettext_lazy as _
 
 from dbbackup import log
 

--- a/dbbackup/apps.py
+++ b/dbbackup/apps.py
@@ -2,9 +2,9 @@
 
 from django.apps import AppConfig
 try:
-    from django.utils.translation import gettext_lazy as _ # noqa: F401
-except: # noqa: E722
-    from django.utils.translation import ugettext_lazy as _ # noqa: F401
+    from django.utils.translation import gettext_lazy as _  # noqa: F401
+except:  # noqa: E722
+    from django.utils.translation import ugettext_lazy as _  # noqa: F401
 
 from dbbackup import log
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix when using django 3.5

## Description
This allow to use any version of django until 3.5 without any warning

## Why should this be added
Better for future versions
