### PR TITLE
Add support for Python 3.9-3.10 and Django 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        django: ["2.2", "3.0", "3.1"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        django: ["2.2", "3.0", "3.1", "3.2"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Database',
         'Topic :: System :: Archiving',
         'Topic :: System :: Archiving :: Backup',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,nightly}-django2.2,py{3.6,3.7,3.8,nightly}-django{3.0,master},lint,docs,functional
+envlist = py{3.6,3.7,3.8,nightly}-django2.2,py{3.6,3.7,3.8,3.9,3.10,nightly}-django{3.0,3.1,3.2,master},lint,docs,functional
 
 [testenv]
 passenv = *
@@ -9,6 +9,8 @@ basepython =
     py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
+    py3.9: python3.9
+    py3.10: python3.10
     pypypy: pypy
     pypypy3: pypy3
     pynightly: python
@@ -17,6 +19,7 @@ deps =
     django2.2: Django>=2.2,<2.3
     django3.0: Django>=3.0,<3.1
     django3.1: Django>=3.1,<3.2
+    django3.2: Django>=3.2,<3.3
     djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:coverage run runtests.py}
 
@@ -25,6 +28,8 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv:lint]
 basepython = python


### PR DESCRIPTION
# Test/CI

## Description

Add support for Python 3.9-3.10 and Django 3.2 to CI test matrix.

## Why should this be added

These are the latest supported versions of Python and Django users are using

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
