### PR TITLE
Add build environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,3 +200,18 @@ Django3.2 you would run:
     tox -e py3.9-django3.2
 
 The available test environments can be found in ``tox.ini``.
+
+Publishing
+==========
+
+To build a source distribution and wheel:
+
+::
+
+    tox -e build
+
+To publish to PyPI:
+
+::
+
+    tox -e upload

--- a/tox.ini
+++ b/tox.ini
@@ -63,3 +63,19 @@ deps =
     -rrequirements-tests.txt
     djongo
 commands = {posargs:bash -x functional.sh}
+
+[testenv:build]
+basepython = python
+skip_install = true
+deps =
+    build
+commands =
+    {envpython} -m build
+
+[testenv:upload]
+basepython = python
+skip_install = true
+deps =
+    twine
+commands =
+    {envpython} -m twine upload {toxinidir}/dist/*


### PR DESCRIPTION
# Build

## Description

Add `build` and `upload` `tox` environments to support uploading wheels along with source distributions (#382).

## Why should this be added

Provide a consistent way to build and upload releases.

## Checklist

- [ ] Documentation has been added or amended for this feature / update
